### PR TITLE
fix: Vercel deployment — SPA mode for correct static routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
   "buildCommand": "pnpm run build",
-  "outputDirectory": "dist",
+  "outputDirectory": "dist/client",
   "framework": null,
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/_shell.html" }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -499,6 +499,7 @@ export default defineConfig({
     browserStorageContextStub(),
     tanstackStart({
       srcDirectory: 'app',
+      spa: {},
     }),
     tsconfigPaths({ projects: ['./tsconfig.json'] }),
   ],


### PR DESCRIPTION
## Problem

All routes on the deployed site returned `404: NOT_FOUND`. The root cause: TanStack Start's Vite-native build outputs client assets to `dist/client/` (not `dist/`), and there's no `index.html` at the root after a fresh build. Our `vercel.json` was pointing to `dist/` expecting an `index.html` that doesn't exist in CI.

## Fix

Two changes:

1. **Enable `spa: {}` in `tanstackStart()`** — activates TanStack Start's built-in SPA mode, which prerenders a shell HTML at `dist/client/_shell.html` during the build. The shell includes the root layout (nav, fonts, theme script) plus the router manifest and hydration entry point.

2. **Update `vercel.json`**:
   - `outputDirectory: "dist/client"` — where the actual client bundle lives
   - Rewrite `/(.*) → /_shell.html` — all routes serve the shell; TanStack Router handles client-side routing

Static assets (`/assets/...`) are served directly by Vercel before rewrites apply, so JS/CSS chunks load correctly.

## Tested

- `pnpm run build` succeeds locally with SPA mode: prerender step runs, `dist/client/_shell.html` is generated
- Shell contains fully rendered root layout + hydration script

🤖 Generated with [Claude Code](https://claude.com/claude-code)