### PR TITLE
fix: golf signal — skip fake pre-event leaderboard

### DIFF
--- a/scripts/signals/golf.js
+++ b/scripts/signals/golf.js
@@ -18,17 +18,32 @@ export async function collect(_profile) {
 
   const event = events[0]
   const tournament = event.name || null
-  const status = event.status?.type?.description || 'Unknown'
+  const statusDescription = event.status?.type?.description || 'Unknown'
+  const statusState = event.status?.type?.state || 'pre'
+
+  // Don't return fake leaders before play has started — competitors are just
+  // field-entry order at this stage, all showing E (even par).
+  if (statusState === 'pre') {
+    return {
+      data: { tournament, status: statusDescription, leaders: [] },
+      meta: { source: 'espn', items: 0 },
+    }
+  }
+
   const competitors = event.competitions?.[0]?.competitors || []
 
-  const leaders = competitors.slice(0, 5).map((c, i) => ({
+  // Sort by ESPN's order field (leaderboard position during/after play),
+  // then take the top 5.
+  const sorted = [...competitors].sort((a, b) => (a.order ?? 999) - (b.order ?? 999))
+
+  const leaders = sorted.slice(0, 5).map(c => ({
     name: c.athlete?.displayName || 'Unknown',
-    position: String(i + 1),
+    position: String(c.order ?? '?'),
     score: typeof c.score === 'string' ? c.score : (c.score?.displayValue || 'E'),
   }))
 
   return {
-    data: { tournament, status, leaders },
+    data: { tournament, status: statusDescription, leaders },
     meta: { source: 'espn', items: leaders.length },
   }
 }

--- a/tests/signals/golf.test.js
+++ b/tests/signals/golf.test.js
@@ -10,17 +10,18 @@ describe('golf provider', () => {
     vi.restoreAllMocks()
   })
 
-  it('returns tournament data from ESPN', async () => {
+  it('returns sorted leaderboard for in-progress tournament', async () => {
     fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
         events: [{
           name: 'The Masters',
-          status: { type: { description: 'In Progress' } },
+          status: { type: { description: 'In Progress', state: 'in' } },
           competitions: [{
             competitors: [
-              { athlete: { displayName: 'Scottie Scheffler' }, status: { position: { displayName: '1' } }, score: { displayValue: '-12' } },
-              { athlete: { displayName: 'Rory McIlroy' }, status: { position: { displayName: '2' } }, score: { displayValue: '-8' } },
+              { order: 2, athlete: { displayName: 'Rory McIlroy' }, score: '-8' },
+              { order: 1, athlete: { displayName: 'Scottie Scheffler' }, score: '-12' },
+              { order: 3, athlete: { displayName: 'Collin Morikawa' }, score: '-6' },
             ],
           }],
         }],
@@ -30,7 +31,36 @@ describe('golf provider', () => {
     const result = await collect({})
     expect(name).toBe('golf')
     expect(result.data.tournament).toBe('The Masters')
-    expect(result.data.leaders.length).toBeGreaterThanOrEqual(1)
+    expect(result.data.status).toBe('In Progress')
+    // Should be sorted by order, not array position
+    expect(result.data.leaders[0].name).toBe('Scottie Scheffler')
+    expect(result.data.leaders[0].score).toBe('-12')
+    expect(result.data.leaders[0].position).toBe('1')
+    expect(result.data.leaders.length).toBe(3)
+  })
+
+  it('returns empty leaders for scheduled (pre-event) tournament', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        events: [{
+          name: 'Houston Open',
+          status: { type: { description: 'Scheduled', state: 'pre' } },
+          competitions: [{
+            competitors: [
+              { order: 1, athlete: { displayName: 'Player A' }, score: 'E' },
+              { order: 2, athlete: { displayName: 'Player B' }, score: 'E' },
+            ],
+          }],
+        }],
+      }),
+    })
+
+    const result = await collect({})
+    expect(result.data.tournament).toBe('Houston Open')
+    expect(result.data.status).toBe('Scheduled')
+    // Pre-event: no real leaderboard, return empty rather than fake field-entry order
+    expect(result.data.leaders).toEqual([])
   })
 
   it('handles no active tournament', async () => {


### PR DESCRIPTION
## Problem

The golf leaderboard on today's build showed 5 players all at E (even par) with \"Scheduled\" status. These are just field-entry order — no play has occurred yet. The site was displaying fake data as if it were live scores.

## Root causes

1. **No pre-event guard** — when `status.type.state === 'pre'`, competitors are listed in field-entry order with no scores. The code was blindly slicing the first 5.
2. **Position used array index** — `map((c, i) => ({ position: String(i + 1) }))` ignores ESPN's actual `c.order` field (the real leaderboard rank during/after play).

## Fix

- Return `leaders: []` when `state === 'pre'` (Scheduled) — no fake leaderboard
- Sort by `c.order` before slicing to top 5 for in-progress/final events
- Use `c.order` as the displayed position instead of array index

## Test plan

- [x] New test: pre-event returns empty leaders
- [x] Existing test updated: in-progress returns leaders sorted by `order` with correct positions
- [x] All 115 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)