### PR TITLE
Fix /elements infinite loop

### DIFF
--- a/app/routes/elements.tsx
+++ b/app/routes/elements.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { Layout } from '../components/Layout'
 import { SectionHead } from '../components/SectionHead'
 import { FeaturedProject } from '../components/FeaturedProject'
 import { ProjectRow } from '../components/ProjectRow'
@@ -262,24 +261,24 @@ const spacingScale: { name: string; value: string }[] = [
 
 const demoRowFull: Project = {
   slug: 'demo-full',
-  title: 'Project Alpha',
+  title: 'FishSticks',
   type: 'SaaS',
-  year: 2023,
+  year: 2025,
   depth: 'full',
 }
 
 const demoRowLight: Project = {
   slug: 'demo-light',
-  title: 'AI Side Project',
-  type: 'AI',
-  year: 2024,
+  title: 'Politweets',
+  type: 'Experiment',
+  year: 2008,
   depth: 'lightweight',
   externalUrl: 'https://example.com',
 }
 
 function Elements() {
   return (
-    <Layout>
+    <>
       <PageTitle>ELEMENTS</PageTitle>
       <PageDesc>The building blocks of this site — design tokens and components from the elements/ preset.</PageDesc>
 
@@ -375,6 +374,6 @@ function Elements() {
           <NfBackLink>← BACK TO WORK</NfBackLink>
         </NfWrap>
       </Section>
-    </Layout>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Removed duplicate `<Layout>` wrapper from `/elements` route — `__root.tsx` already wraps all routes in Layout, so the double wrap caused an infinite render loop
- Updated demo project data to use real names (FishSticks, Politweets) instead of placeholders

## Test plan
- [ ] Navigate to `/elements` — should render without freezing
- [ ] All 116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)