### PR TITLE
Archive page: list + detail with design brief, tokens, signals

### DIFF
--- a/.github/workflows/daily-redesign.yml
+++ b/.github/workflows/daily-redesign.yml
@@ -63,4 +63,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --cached --quiet || git commit -m "chore: daily redesign $(date +%Y-%m-%d)"
+          git pull --rebase origin main
           git push origin main

--- a/app/content/timeline.ts
+++ b/app/content/timeline.ts
@@ -143,7 +143,7 @@ export const education: Education = {
   school: 'The University of Dayton',
   degree: 'Bachelor of Fine Arts',
   concentration: 'Visual Communication and Design',
-  years: '1995 — 1999',
+  years: '',
 }
 
 export const capabilities = [

--- a/app/routes/archive.$date.tsx
+++ b/app/routes/archive.$date.tsx
@@ -1,0 +1,469 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { readArchiveDetail } from '../server/archive'
+
+export const Route = createFileRoute('/archive/$date')({
+  loader: async ({ params }) => {
+    const detail = await readArchiveDetail({ data: params.date })
+    if (!detail) throw new Error('Archive entry not found')
+    return { detail }
+  },
+  component: ArchiveDetailPage,
+  errorComponent: () => (
+    <div style={{ padding: '80px 48px', maxWidth: 800, margin: '0 auto' }}>
+      <h2
+        style={{
+          fontSize: '1.5rem',
+          marginBottom: 16,
+          color: 'var(--colors-text, #111)',
+        }}
+      >
+        Archive entry not found
+      </h2>
+      <Link
+        to="/archive"
+        style={{ color: 'var(--colors-accent, #666)', textDecoration: 'none' }}
+      >
+        ← Back to Archive
+      </Link>
+    </div>
+  ),
+})
+
+/* ---------------------------------------------------------------------------
+ * Preset parser — extracts colors, fonts, and font sizes from the raw
+ * TypeScript preset string using regex.
+ * ------------------------------------------------------------------------- */
+
+interface ParsedTokens {
+  colors: { name: string; hex: string }[]
+  fonts: string[]
+  fontSizes: { name: string; value: string }[]
+}
+
+function parsePreset(preset: string): ParsedTokens {
+  const colors: ParsedTokens['colors'] = []
+  const fonts: string[] = []
+  const fontSizes: ParsedTokens['fontSizes'] = []
+
+  // Colors: match key-value pairs like  primary: '#AABBCC'  or  bg: '#FFF'
+  // Also handles nested objects like  primary: { value: '#AABBCC' }
+  const colorHexRe = /(\w[\w-]*):\s*['{"]?(#[0-9A-Fa-f]{3,8})['"}\s,]/g
+  let m: RegExpExecArray | null
+  const seen = new Set<string>()
+  while ((m = colorHexRe.exec(preset)) !== null) {
+    const name = m[1]
+    const hex = m[2]
+    const key = `${name}-${hex}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      colors.push({ name, hex })
+    }
+  }
+
+  // Fonts: look for font family values
+  const fontRe = /fonts[\s\S]*?value:\s*'([^']+)'/g
+  while ((m = fontRe.exec(preset)) !== null) {
+    if (!fonts.includes(m[1])) fonts.push(m[1])
+  }
+
+  // Also catch fontFamily patterns
+  const fontFamilyRe = /fontFamily[^:]*:\s*['"]([^'"]+)['"]/g
+  while ((m = fontFamilyRe.exec(preset)) !== null) {
+    if (!fonts.includes(m[1])) fonts.push(m[1])
+  }
+
+  // Font sizes: key-value pairs in a fontSizes block
+  const fontSizeBlock = preset.match(/fontSizes[\s\S]*?\{([\s\S]*?)\}/)?.[1]
+  if (fontSizeBlock) {
+    const sizeRe = /(\w+):\s*['"]([^'"]+)['"]/g
+    while ((m = sizeRe.exec(fontSizeBlock)) !== null) {
+      fontSizes.push({ name: m[1], value: m[2] })
+    }
+  }
+
+  return { colors, fonts, fontSizes }
+}
+
+/* ---------------------------------------------------------------------------
+ * Signals parser — splits markdown on ## headings into sections.
+ * ------------------------------------------------------------------------- */
+
+interface SignalSection {
+  heading: string
+  body: string
+}
+
+function parseSignals(md: string): SignalSection[] {
+  const sections: SignalSection[] = []
+  const parts = md.split(/^## /m).filter(Boolean)
+  for (const part of parts) {
+    const newline = part.indexOf('\n')
+    if (newline === -1) {
+      sections.push({ heading: part.trim(), body: '' })
+    } else {
+      sections.push({
+        heading: part.slice(0, newline).trim(),
+        body: part.slice(newline + 1).trim(),
+      })
+    }
+  }
+  return sections
+}
+
+/* ---------------------------------------------------------------------------
+ * Date formatting
+ * ------------------------------------------------------------------------- */
+
+function formatDate(date: string): string {
+  try {
+    const d = new Date(date + 'T12:00:00')
+    return d.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  } catch {
+    return date
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Page component
+ * ------------------------------------------------------------------------- */
+
+function ArchiveDetailPage() {
+  const { detail } = Route.useLoaderData()
+  const tokens = detail.preset ? parsePreset(detail.preset) : null
+  const signals = detail.signalsBrief ? parseSignals(detail.signalsBrief) : null
+
+  return (
+    <>
+      {/* ── Section 1: Design Brief ─────────────────────────────────── */}
+      <section
+        style={{
+          maxWidth: 720,
+          margin: '0 auto',
+          padding: '120px 48px 80px',
+        }}
+      >
+        {detail.archetype && (
+          <p
+            style={{
+              fontVariant: 'all-small-caps',
+              letterSpacing: '0.15em',
+              fontSize: 12,
+              color: 'var(--colors-text-dim, #888)',
+              marginBottom: 8,
+            }}
+          >
+            {detail.archetype}
+          </p>
+        )}
+
+        <time
+          dateTime={detail.date}
+          style={{
+            display: 'block',
+            fontSize: 13,
+            color: 'var(--colors-text-dim, #999)',
+            fontVariantNumeric: 'tabular-nums',
+            marginBottom: 32,
+          }}
+        >
+          {formatDate(detail.date)}
+        </time>
+
+        {detail.brief && (
+          <h1
+            style={{
+              fontSize: 28,
+              fontWeight: 600,
+              lineHeight: 1.45,
+              color: 'var(--colors-text, #111)',
+              marginBottom: 32,
+              maxWidth: 640,
+            }}
+          >
+            {detail.brief}
+          </h1>
+        )}
+
+        {detail.rationale && (
+          <div
+            style={{
+              fontSize: 15,
+              lineHeight: 1.7,
+              color: 'var(--colors-text-dim, #555)',
+              maxWidth: 640,
+            }}
+          >
+            {detail.rationale.split('\n\n').map((para, i) => (
+              <p key={i} style={{ marginBottom: 16 }}>
+                {para}
+              </p>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Section 2: Tokens ───────────────────────────────────────── */}
+      <section
+        style={{
+          maxWidth: 720,
+          margin: '0 auto',
+          padding: '0 48px 64px',
+        }}
+      >
+        <p
+          style={{
+            fontVariant: 'all-small-caps',
+            letterSpacing: '0.15em',
+            fontSize: 12,
+            color: 'var(--colors-text-dim, #888)',
+            marginBottom: 24,
+          }}
+        >
+          TOKENS
+        </p>
+
+        {!detail.preset ? (
+          <p
+            style={{
+              fontSize: 14,
+              color: 'var(--colors-text-dim, #999)',
+              fontStyle: 'italic',
+            }}
+          >
+            Tokens not available for this build.
+          </p>
+        ) : (
+          <>
+            {/* Color swatches */}
+            {tokens && tokens.colors.length > 0 && (
+              <div style={{ marginBottom: 32 }}>
+                <p
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: 'var(--colors-text, #111)',
+                    marginBottom: 12,
+                  }}
+                >
+                  Colors
+                </p>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: 12,
+                  }}
+                >
+                  {tokens.colors.map((c, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        gap: 6,
+                      }}
+                    >
+                      <div
+                        style={{
+                          width: 40,
+                          height: 40,
+                          borderRadius: 6,
+                          backgroundColor: c.hex,
+                          border: '1px solid var(--colors-border, #e0e0e0)',
+                        }}
+                      />
+                      <span
+                        style={{
+                          fontSize: 10,
+                          color: 'var(--colors-text-dim, #999)',
+                          fontFamily: 'monospace',
+                        }}
+                      >
+                        {c.hex}
+                      </span>
+                      <span
+                        style={{
+                          fontSize: 10,
+                          color: 'var(--colors-text-dim, #aaa)',
+                        }}
+                      >
+                        {c.name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Fonts */}
+            {tokens && tokens.fonts.length > 0 && (
+              <div style={{ marginBottom: 32 }}>
+                <p
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: 'var(--colors-text, #111)',
+                    marginBottom: 12,
+                  }}
+                >
+                  Typography
+                </p>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                  {tokens.fonts.map((font, i) => (
+                    <div key={i}>
+                      <p
+                        style={{
+                          fontSize: 20,
+                          fontFamily: font,
+                          color: 'var(--colors-text, #111)',
+                          marginBottom: 4,
+                        }}
+                      >
+                        {font}
+                      </p>
+                      <p
+                        style={{
+                          fontSize: 12,
+                          color: 'var(--colors-text-dim, #999)',
+                          fontFamily: 'monospace',
+                        }}
+                      >
+                        {font}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Font sizes */}
+            {tokens && tokens.fontSizes.length > 0 && (
+              <div>
+                <p
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: 'var(--colors-text, #111)',
+                    marginBottom: 12,
+                  }}
+                >
+                  Scale
+                </p>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: '8px 24px',
+                  }}
+                >
+                  {tokens.fontSizes.map((s, i) => (
+                    <span
+                      key={i}
+                      style={{
+                        fontSize: 13,
+                        color: 'var(--colors-text-dim, #777)',
+                        fontFamily: 'monospace',
+                      }}
+                    >
+                      {s.name}: {s.value}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* ── Section 3: Signals ──────────────────────────────────────── */}
+      <section
+        style={{
+          maxWidth: 720,
+          margin: '0 auto',
+          padding: '0 48px 64px',
+        }}
+      >
+        <p
+          style={{
+            fontVariant: 'all-small-caps',
+            letterSpacing: '0.15em',
+            fontSize: 12,
+            color: 'var(--colors-text-dim, #888)',
+            marginBottom: 24,
+          }}
+        >
+          SIGNALS
+        </p>
+
+        {!detail.signalsBrief ? (
+          <p
+            style={{
+              fontSize: 14,
+              color: 'var(--colors-text-dim, #999)',
+              fontStyle: 'italic',
+            }}
+          >
+            Signals brief not available for this build.
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 28 }}>
+            {signals?.map((section, i) => (
+              <div key={i}>
+                <p
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: 'var(--colors-text, #111)',
+                    marginBottom: 8,
+                  }}
+                >
+                  {section.heading}
+                </p>
+                <div
+                  style={{
+                    fontSize: 14,
+                    lineHeight: 1.65,
+                    color: 'var(--colors-text-dim, #666)',
+                  }}
+                >
+                  {section.body.split('\n\n').map((para, j) => (
+                    <p key={j} style={{ marginBottom: 10 }}>
+                      {para}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Section 4: Actions ──────────────────────────────────────── */}
+      <section
+        style={{
+          maxWidth: 720,
+          margin: '0 auto',
+          padding: '0 48px 120px',
+        }}
+      >
+        <Link
+          to="/archive"
+          style={{
+            fontSize: 14,
+            color: 'var(--colors-accent, #666)',
+            textDecoration: 'none',
+          }}
+        >
+          ← Back to Archive
+        </Link>
+        {/* TODO: "View archived site" link — requires serving archived HTML snapshots */}
+      </section>
+    </>
+  )
+}

--- a/app/routes/archive.tsx
+++ b/app/routes/archive.tsx
@@ -1,7 +1,5 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { readArchive, type ArchiveEntry } from '../server/archive'
-import { Box, Flex, VStack } from '../../styled-system/jsx'
-import { css } from '../../styled-system/css'
 
 export const Route = createFileRoute('/archive')({
   loader: async () => {
@@ -11,242 +9,153 @@ export const Route = createFileRoute('/archive')({
   component: ArchivePage,
 })
 
+function truncate(text: string, max: number) {
+  if (text.length <= max) return text
+  return text.slice(0, max).replace(/\s+\S*$/, '') + '...'
+}
+
 function ArchivePage() {
   const { entries } = Route.useLoaderData()
 
   return (
-    <Box as="main">
-      {/* ─── Header ─── */}
-      <Box
-        as="section"
+    <>
+      {/* Header */}
+      <section
         style={{
-          minHeight: '40vh',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          padding: '120px 48px 80px',
-          maxWidth: '960px',
+          maxWidth: 760,
           margin: '0 auto',
+          padding: '120px 48px 64px',
         }}
       >
-        <Box
-          fontFamily="body"
-          fontWeight="400"
-          fontSize="2xs"
-          color="textMuted"
-          letterSpacing="widest"
-          style={{ textTransform: 'uppercase', marginBottom: '32px' }}
+        <p
+          style={{
+            fontVariant: 'all-small-caps',
+            letterSpacing: '0.15em',
+            fontSize: 12,
+            color: 'var(--colors-text-dim, #888)',
+            marginBottom: 16,
+          }}
         >
-          Archive
-        </Box>
-
-        <Box
-          fontFamily="heading"
-          fontWeight="700"
-          fontSize="xl"
-          color="text"
-          letterSpacing="tight"
-          lineHeight="tight"
-          style={{ marginBottom: '32px', textTransform: 'uppercase' }}
+          ARCHIVE
+        </p>
+        <h1
+          style={{
+            fontSize: 36,
+            fontWeight: 700,
+            color: 'var(--colors-text, #111)',
+            marginBottom: 16,
+            lineHeight: 1.15,
+          }}
         >
           Daily Redesigns
-        </Box>
-
-        <Box
+        </h1>
+        <p
           style={{
-            width: '80px',
-            borderTop: '1px solid #a3b49d',
-            marginBottom: '32px',
-          }}
-        />
-
-        <Box
-          fontFamily="body"
-          fontWeight="400"
-          fontSize="base"
-          color="textBody"
-          lineHeight="normal"
-          style={{ maxWidth: '520px' }}
-        >
-          Every morning, a multi-agent pipeline redesigns this site from scratch. Each entry below is one day's output — the brief, the rationale, and what changed.
-        </Box>
-      </Box>
-
-      {/* ─── Entries ─── */}
-      <Box
-        as="section"
-        style={{
-          background: '#eaf0e6',
-          width: '100%',
-          display: 'flex',
-          justifyContent: 'center',
-        }}
-      >
-        <Box
-          style={{
-            maxWidth: '760px',
-            width: '100%',
-            padding: '80px 48px',
+            fontSize: 15,
+            lineHeight: 1.6,
+            color: 'var(--colors-text-dim, #666)',
+            maxWidth: 520,
           }}
         >
-          {entries.length === 0 ? (
-            <Box
-              fontFamily="body"
-              fontWeight="300"
-              fontSize="sm"
-              color="textMuted"
-            >
-              No archive entries yet.
-            </Box>
-          ) : (
-            <VStack gap="0" align="stretch">
-              {entries.map((entry, i) => (
-                <ArchiveEntryRow key={entry.date} entry={entry} index={i} total={entries.length} />
-              ))}
-            </VStack>
-          )}
-        </Box>
-      </Box>
+          Every morning a multi-agent pipeline redesigns this site from scratch.
+          Each entry below is one day's output.
+        </p>
+      </section>
 
-      {/* ─── Footer ─── */}
-      <Box
-        as="footer"
+      {/* Entry list */}
+      <section
         style={{
-          background: '#2a322a',
-          padding: '48px 48px',
-          display: 'flex',
-          justifyContent: 'center',
+          maxWidth: 760,
+          margin: '0 auto',
+          padding: '0 48px 120px',
         }}
       >
-        <Flex
-          justify="space-between"
-          align="center"
-          style={{ maxWidth: '760px', width: '100%' }}
-        >
-          <a
-            href="/"
-            className={css({
-              fontFamily: 'heading',
-              fontSize: 'xs',
-              letterSpacing: 'wider',
-              textDecoration: 'none',
-              transition: 'color 200ms ease',
-              _hover: { color: 'accentLight' },
-            })}
-            style={{ color: '#a3b49d' }}
-          >
-            ← Work
-          </a>
-          <Box
-            fontFamily="body"
-            fontWeight="300"
-            fontSize="xs"
-            style={{ color: '#596658' }}
-          >
-            © 2026 Doug March
-          </Box>
-        </Flex>
-      </Box>
-    </Box>
+        {entries.length === 0 ? (
+          <p style={{ color: 'var(--colors-text-dim, #888)', fontSize: 14 }}>
+            No archive entries yet.
+          </p>
+        ) : (
+          entries.map((entry, i) => (
+            <ArchiveRow
+              key={entry.date}
+              entry={entry}
+              isLast={i === entries.length - 1}
+            />
+          ))
+        )}
+      </section>
+    </>
   )
 }
 
-function ArchiveEntryRow({
+function ArchiveRow({
   entry,
-  index,
-  total,
+  isLast,
 }: {
   entry: ArchiveEntry
-  index: number
-  total: number
+  isLast: boolean
 }) {
-  const isLast = index === total - 1
-
   return (
-    <Box
+    <Link
+      to="/archive/$date"
+      params={{ date: entry.date }}
       style={{
-        padding: '32px 0',
-        borderBottom: isLast ? 'none' : '1px solid #c9d5c4',
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 24,
+        padding: '20px 12px',
+        borderBottom: isLast
+          ? 'none'
+          : '1px solid var(--colors-border, #e0e0e0)',
+        textDecoration: 'none',
+        color: 'inherit',
+        transition: 'background 150ms ease',
+      }}
+      onMouseEnter={(e) => {
+        ;(e.currentTarget as HTMLElement).style.background =
+          'var(--colors-accent, rgba(0,0,0,0.04))'
+      }}
+      onMouseLeave={(e) => {
+        ;(e.currentTarget as HTMLElement).style.background = 'transparent'
       }}
     >
-      {/* Date + index */}
-      <Flex align="center" gap="4" style={{ marginBottom: '16px' }}>
-        <Box
-          fontFamily="body"
-          fontWeight="400"
-          fontSize="2xs"
-          color="textMuted"
-          letterSpacing="widest"
-          style={{ textTransform: 'uppercase', fontVariantNumeric: 'tabular-nums' }}
-        >
-          {entry.date}
-        </Box>
-        <Box
+      {/* Left: archetype + brief */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <span
           style={{
-            width: '1px',
-            height: '10px',
-            background: '#c9d5c4',
+            fontWeight: 600,
+            fontSize: 16,
+            color: 'var(--colors-text, #111)',
+            display: 'block',
+            marginBottom: 4,
           }}
-        />
-        <Box
-          fontFamily="body"
-          fontWeight="400"
-          fontSize="2xs"
-          color="textMuted"
-          style={{ fontVariantNumeric: 'tabular-nums' }}
         >
-          #{String(index + 1).padStart(2, '0')}
-        </Box>
-      </Flex>
+          {entry.archetype || 'Untitled'}
+        </span>
+        <span
+          style={{
+            fontSize: 13,
+            color: 'var(--colors-text-dim, #888)',
+            lineHeight: 1.4,
+          }}
+        >
+          {truncate(entry.brief, 120)}
+        </span>
+      </div>
 
-      {/* Brief */}
-      <Box
-        fontFamily="heading"
-        fontWeight="600"
-        fontSize="base"
-        color="text"
-        style={{ marginBottom: '12px' }}
+      {/* Right: date */}
+      <time
+        dateTime={entry.date}
+        style={{
+          fontSize: 13,
+          fontVariantNumeric: 'tabular-nums',
+          color: 'var(--colors-text-dim, #999)',
+          whiteSpace: 'nowrap',
+          flexShrink: 0,
+        }}
       >
-        {entry.brief}
-      </Box>
-
-      {/* Rationale */}
-      {entry.rationale && (
-        <Box
-          fontFamily="body"
-          fontWeight="300"
-          fontSize="sm"
-          color="textMuted"
-          lineHeight="normal"
-          style={{ marginBottom: '16px', maxWidth: '600px' }}
-        >
-          {entry.rationale}
-        </Box>
-      )}
-
-      {/* Files changed */}
-      {entry.filesChanged.length > 0 && (
-        <Flex gap="2" style={{ flexWrap: 'wrap' }}>
-          {entry.filesChanged.map((file) => (
-            <Box
-              key={file}
-              fontFamily="body"
-              fontWeight="400"
-              fontSize="2xs"
-              color="textMuted"
-              style={{
-                padding: '3px 8px',
-                background: 'rgba(163, 180, 157, 0.2)',
-                border: '1px solid #c9d5c4',
-                fontVariantNumeric: 'tabular-nums',
-                letterSpacing: '0.01em',
-              }}
-            >
-              {file}
-            </Box>
-          ))}
-        </Flex>
-      )}
-    </Box>
+        {entry.date}
+      </time>
+    </Link>
   )
 }

--- a/app/routes/archive.tsx
+++ b/app/routes/archive.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, Outlet, useMatch } from '@tanstack/react-router'
 import { readArchive, type ArchiveEntry } from '../server/archive'
 
 export const Route = createFileRoute('/archive')({
@@ -16,6 +16,12 @@ function truncate(text: string, max: number) {
 
 function ArchivePage() {
   const { entries } = Route.useLoaderData()
+  const childMatch = useMatch({ from: '/archive/$date', shouldThrow: false })
+
+  // If a child route is active, render only the child (Outlet)
+  if (childMatch) {
+    return <Outlet />
+  }
 
   return (
     <>

--- a/app/server/archive-detail-impl.ts
+++ b/app/server/archive-detail-impl.ts
@@ -1,0 +1,72 @@
+// app/server/archive-detail-impl.ts
+// Pure implementation — no server function wrappers, safe to import in tests
+import { readFileSync, existsSync, readdirSync } from 'fs'
+import { join } from 'path'
+import { ARCHIVE_PATH } from './archive-impl'
+
+export interface ArchiveDetail {
+  date: string
+  archetype: string
+  brief: string
+  signalsBrief: string
+  preset: string
+  rationale: string
+  filesChanged: string[]
+  hasScreenshot: boolean
+  buildId: string
+}
+
+export function _readArchiveDetail(date: string, archivePath = ARCHIVE_PATH): ArchiveDetail | null {
+  const dateDir = join(archivePath, date)
+  if (!existsSync(dateDir)) return null
+
+  const readSafe = (p: string) => existsSync(p) ? readFileSync(p, 'utf8') : ''
+
+  // Find latest build directory
+  const builds = readdirSync(dateDir, { withFileTypes: true })
+    .filter(b => b.isDirectory() && b.name.startsWith('build-'))
+    .map(b => b.name)
+    .sort()
+    .reverse()
+  const latestBuild = builds[0]
+
+  // Fall back to top-level date dir for older builds without build-* dirs
+  const buildDir = latestBuild ? join(dateDir, latestBuild) : null
+  const buildId = latestBuild?.replace('build-', '') ?? ''
+
+  const briefContent = buildDir
+    ? readSafe(join(buildDir, 'brief.md'))
+    : readSafe(join(dateDir, 'brief.md'))
+
+  const signalsBrief = buildDir ? readSafe(join(buildDir, 'signals-brief.md')) : ''
+  const preset = buildDir ? readSafe(join(buildDir, 'preset.ts')) : ''
+  const hasScreenshot = buildDir ? existsSync(join(buildDir, 'screenshot.png')) : false
+  const archetype = readSafe(join(dateDir, 'archetype.txt')).trim()
+
+  // Parse brief.md
+  const lines = briefContent.split('\n')
+  const briefLine = lines.find(l => l.startsWith('**Design Brief:** '))
+  const brief = briefLine?.slice('**Design Brief:** '.length).trim() ?? ''
+
+  let rationale = ''
+  const rationaleStart = lines.findIndex(l => l.startsWith("## Claude's Rationale"))
+  const filesChangedStart = lines.findIndex(l => l.startsWith('## Files Changed'))
+  if (rationaleStart !== -1 && filesChangedStart !== -1) {
+    rationale = lines.slice(rationaleStart + 1, filesChangedStart).join('\n').trim()
+  } else if (rationaleStart !== -1) {
+    rationale = lines.slice(rationaleStart + 1).join('\n').trim()
+  }
+
+  const filesChanged: string[] = []
+  if (filesChangedStart !== -1) {
+    for (let i = filesChangedStart + 1; i < lines.length; i++) {
+      const line = lines[i].trim()
+      if (line.startsWith('- ')) filesChanged.push(line.slice(2).trim())
+    }
+  }
+
+  return {
+    date, archetype, brief, signalsBrief, preset,
+    rationale, filesChanged, hasScreenshot, buildId,
+  }
+}

--- a/app/server/archive-impl.ts
+++ b/app/server/archive-impl.ts
@@ -10,6 +10,8 @@ export interface ArchiveEntry {
   brief: string
   rationale: string
   filesChanged: string[]
+  archetype: string
+  buildId: string
 }
 
 export function _readArchiveHandler(archivePath = ARCHIVE_PATH): ArchiveEntry[] {
@@ -18,7 +20,27 @@ export function _readArchiveHandler(archivePath = ARCHIVE_PATH): ArchiveEntry[] 
   return readdirSync(archivePath, { withFileTypes: true })
     .filter(d => d.isDirectory())
     .map(d => {
-      const briefPath = join(archivePath, d.name, 'brief.md')
+      const dateDir = join(archivePath, d.name)
+
+      // Read archetype
+      const archetypePath = join(dateDir, 'archetype.txt')
+      const archetype = existsSync(archetypePath)
+        ? readFileSync(archetypePath, 'utf8').trim()
+        : ''
+
+      // Find latest build directory
+      const builds = readdirSync(dateDir, { withFileTypes: true })
+        .filter(b => b.isDirectory() && b.name.startsWith('build-'))
+        .map(b => b.name)
+        .sort()
+        .reverse()
+      const latestBuild = builds[0]
+      const buildId = latestBuild?.replace('build-', '') ?? ''
+
+      // Read brief.md from build dir if available, else from date dir
+      const briefPath = latestBuild
+        ? join(dateDir, latestBuild, 'brief.md')
+        : join(dateDir, 'brief.md')
       if (!existsSync(briefPath)) return null
       const content = readFileSync(briefPath, 'utf8')
       const lines = content.split('\n')
@@ -53,9 +75,10 @@ export function _readArchiveHandler(archivePath = ARCHIVE_PATH): ArchiveEntry[] 
         brief: briefLine.slice('**Design Brief:** '.length).trim(),
         rationale,
         filesChanged,
+        archetype,
+        buildId,
       }
     })
     .filter((e): e is ArchiveEntry => e !== null)
     .sort((a, b) => b.date.localeCompare(a.date))
-    .slice(0, 10)
 }

--- a/app/server/archive.ts
+++ b/app/server/archive.ts
@@ -10,7 +10,7 @@ export const readArchive = createServerFn({ method: 'GET' })
   .handler(() => _readArchiveHandler())
 
 export const readArchiveDetail = createServerFn({ method: 'GET' })
-  .validator((date: string) => date)
+  .inputValidator((d: unknown) => d as string)
   .handler(async ({ data: date }) => {
     return _readArchiveDetail(date)
   })

--- a/app/server/archive.ts
+++ b/app/server/archive.ts
@@ -2,7 +2,15 @@
 'use server'
 import { createServerFn } from '@tanstack/react-start'
 import { _readArchiveHandler } from './archive-impl'
+import { _readArchiveDetail } from './archive-detail-impl'
 export type { ArchiveEntry } from './archive-impl'
+export type { ArchiveDetail } from './archive-detail-impl'
 
 export const readArchive = createServerFn({ method: 'GET' })
   .handler(() => _readArchiveHandler())
+
+export const readArchiveDetail = createServerFn({ method: 'GET' })
+  .validator((date: string) => date)
+  .handler(async ({ data: date }) => {
+    return _readArchiveDetail(date)
+  })

--- a/scripts/prompts/unified-designer.md
+++ b/scripts/prompts/unified-designer.md
@@ -12,6 +12,7 @@ A personal portfolio for Doug March — Product Designer & Developer. The site h
 - Name: "Doug March"
 - Role: "Product Designer & Developer"
 - Navigation: Home (/), About (/about)
+- Footer: Include a small "Archive" link to /archive somewhere in the footer area of the page. It should not stand out — it should feel like a natural, understated part of whatever content it sits near. Same typographic treatment as surrounding footer text, no special emphasis.
 
 **Portfolio (the primary content — this is a portfolio site):**
 - One featured project (Spaceman) — title, problem statement, external link

--- a/scripts/utils/archiver.js
+++ b/scripts/utils/archiver.js
@@ -1,4 +1,5 @@
-import { mkdir, writeFile } from 'fs/promises'
+import { mkdir, writeFile, readFile } from 'fs/promises'
+import { existsSync } from 'fs'
 import path from 'path'
 import { ROOT } from './file-manager.js'
 import { captureSnapshot } from './snapshot.js'
@@ -123,6 +124,24 @@ export async function archive(date, signals, rationale, designBrief, changedFile
   await writeFile(path.join(buildDir, 'build.json'), JSON.stringify(buildMeta, null, 2), 'utf8')
   console.log(`  archived to archive/${dateStr}/build-${buildId}/`)
 
+  // Save the interpreted signals brief if it exists
+  const signalsBriefSrc = path.join(ROOT, 'signals', 'today.brief.md')
+  if (existsSync(signalsBriefSrc)) {
+    try {
+      const signalsBrief = await readFile(signalsBriefSrc, 'utf8')
+      await writeFile(path.join(buildDir, 'signals-brief.md'), signalsBrief, 'utf8')
+    } catch { /* signals brief read failed — non-blocking */ }
+  }
+
+  // Save the design tokens preset
+  const presetSrc = path.join(ROOT, 'elements', 'preset.ts')
+  if (existsSync(presetSrc)) {
+    try {
+      const preset = await readFile(presetSrc, 'utf8')
+      await writeFile(path.join(buildDir, 'preset.ts'), preset, 'utf8')
+    } catch { /* preset read failed — non-blocking */ }
+  }
+
   // Also save/overwrite the top-level brief.md as the "latest" for backwards compatibility
   // (the Design Director reads archive/{date}/brief.md)
   const latestBriefPath = path.join(dir, 'brief.md')
@@ -133,5 +152,36 @@ export async function archive(date, signals, rationale, designBrief, changedFile
     await captureSnapshot(dateStr, buildId)
   } catch (err) {
     console.warn(`  snapshot failed (non-blocking): ${err.message}`)
+  }
+
+  // Capture a thumbnail screenshot into the build directory (best-effort)
+  try {
+    const { spawnSync } = await import('child_process')
+    const net = await import('net')
+    const portOpen = await new Promise(resolve => {
+      const sock = new net.Socket()
+      sock.setTimeout(2000)
+      sock.once('connect', () => { sock.destroy(); resolve(true) })
+      sock.once('error', () => resolve(false))
+      sock.once('timeout', () => { sock.destroy(); resolve(false) })
+      sock.connect(5173, '127.0.0.1')
+    })
+    if (portOpen) {
+      const screenshotPath = path.join(buildDir, 'screenshot.png')
+      const result = spawnSync('node', [
+        path.join(ROOT, 'scripts', 'capture-reference.js'),
+        '--port=5173',
+        `--output=${screenshotPath}`,
+      ], { timeout: 45000 })
+      if (result.status === 0) {
+        console.log(`  screenshot saved to build-${buildId}/screenshot.png`)
+      } else {
+        console.warn(`  screenshot capture failed (non-blocking)`)
+      }
+    } else {
+      console.log(`  dev server not running, skipping screenshot`)
+    }
+  } catch (err) {
+    console.warn(`  screenshot failed (non-blocking): ${err.message}`)
   }
 }

--- a/tests/server/archive-detail.test.ts
+++ b/tests/server/archive-detail.test.ts
@@ -1,0 +1,78 @@
+// tests/server/archive-detail.test.ts
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdirSync, writeFileSync, rmSync } from 'fs'
+import { join } from 'path'
+import { _readArchiveDetail } from '../../app/server/archive-detail-impl'
+
+const TEST_ARCHIVE = join(process.cwd(), 'archive', '__test-detail__')
+
+describe('archive detail', () => {
+  const dateWithBuild = '2099-01-01'
+  const dateDir = join(TEST_ARCHIVE, dateWithBuild)
+  const buildDir = join(dateDir, 'build-9999999999999')
+
+  const dateNoBuild = '2099-01-02'
+  const dateDirNoBuild = join(TEST_ARCHIVE, dateNoBuild)
+
+  beforeAll(() => {
+    mkdirSync(buildDir, { recursive: true })
+    writeFileSync(join(dateDir, 'archetype.txt'), 'Specimen')
+    writeFileSync(join(buildDir, 'brief.md'), [
+      '# 2099-01-01', '',
+      '**Design Brief:** Test brief content', '',
+      '## Signals', '',
+      "## Claude's Rationale", '',
+      'Test rationale paragraph.', '',
+      '## Files Changed', '',
+      '- app/routes/index.tsx',
+      '- elements/preset.ts',
+    ].join('\n'))
+    writeFileSync(join(buildDir, 'signals-brief.md'), '# Signals Brief\n\n## Mood\nTest mood')
+    writeFileSync(join(buildDir, 'preset.ts'), 'export const preset = {}')
+
+    mkdirSync(dateDirNoBuild, { recursive: true })
+    writeFileSync(join(dateDirNoBuild, 'archetype.txt'), 'Poster')
+    writeFileSync(join(dateDirNoBuild, 'brief.md'), [
+      '# 2099-01-02', '',
+      '**Design Brief:** Old format brief', '',
+      "## Claude's Rationale", '',
+      'Old rationale.', '',
+      '## Files Changed', '',
+      '- app/routes/index.tsx',
+    ].join('\n'))
+  })
+
+  afterAll(() => {
+    rmSync(TEST_ARCHIVE, { recursive: true, force: true })
+  })
+
+  it('reads all artifacts for a date with build directory', () => {
+    const result = _readArchiveDetail(dateWithBuild, TEST_ARCHIVE)
+    expect(result).not.toBeNull()
+    expect(result!.date).toBe(dateWithBuild)
+    expect(result!.archetype).toBe('Specimen')
+    expect(result!.brief).toBe('Test brief content')
+    expect(result!.rationale).toBe('Test rationale paragraph.')
+    expect(result!.signalsBrief).toContain('## Mood')
+    expect(result!.preset).toContain('export const preset')
+    expect(result!.filesChanged).toEqual(['app/routes/index.tsx', 'elements/preset.ts'])
+    expect(result!.buildId).toBe('9999999999999')
+    expect(result!.hasScreenshot).toBe(false)
+  })
+
+  it('falls back to top-level brief.md when no build directory exists', () => {
+    const result = _readArchiveDetail(dateNoBuild, TEST_ARCHIVE)
+    expect(result).not.toBeNull()
+    expect(result!.archetype).toBe('Poster')
+    expect(result!.brief).toBe('Old format brief')
+    expect(result!.rationale).toBe('Old rationale.')
+    expect(result!.signalsBrief).toBe('')
+    expect(result!.preset).toBe('')
+    expect(result!.buildId).toBe('')
+  })
+
+  it('returns null for non-existent date', () => {
+    const result = _readArchiveDetail('9999-99-99', TEST_ARCHIVE)
+    expect(result).toBeNull()
+  })
+})

--- a/tests/server/archive.test.ts
+++ b/tests/server/archive.test.ts
@@ -8,14 +8,23 @@ import { _readArchiveHandler } from '../../app/server/archive-impl.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const FIXTURES_DIR = resolve(__dirname, '../fixtures/archive')
 
-function writeArchiveEntry(date: string, brief: string) {
+function writeArchiveEntry(date: string, brief: string, opts?: { archetype?: string; buildId?: string }) {
   const dir = resolve(FIXTURES_DIR, date)
   mkdirSync(dir, { recursive: true })
-  writeFileSync(
-    resolve(dir, 'brief.md'),
-    `# ${date}\n\n**Design Brief:** ${brief}\n\n## Signals\n`,
-    'utf8'
-  )
+
+  if (opts?.archetype) {
+    writeFileSync(resolve(dir, 'archetype.txt'), opts.archetype, 'utf8')
+  }
+
+  const briefContent = `# ${date}\n\n**Design Brief:** ${brief}\n\n## Signals\n`
+
+  if (opts?.buildId) {
+    const buildDir = resolve(dir, `build-${opts.buildId}`)
+    mkdirSync(buildDir, { recursive: true })
+    writeFileSync(resolve(buildDir, 'brief.md'), briefContent, 'utf8')
+  } else {
+    writeFileSync(resolve(dir, 'brief.md'), briefContent, 'utf8')
+  }
 }
 
 afterEach(() => {
@@ -52,11 +61,25 @@ describe('_readArchiveHandler', () => {
     expect(result).toHaveLength(0)
   })
 
-  it('returns at most 10 entries', () => {
+  it('returns all entries without a limit', () => {
     for (let i = 1; i <= 12; i++) {
       writeArchiveEntry(`2026-03-${String(i).padStart(2, '0')}`, `Design ${i}`)
     }
     const result = _readArchiveHandler(FIXTURES_DIR)
-    expect(result).toHaveLength(10)
+    expect(result).toHaveLength(12)
+  })
+
+  it('includes archetype and buildId fields', () => {
+    writeArchiveEntry('2026-03-14', 'Brutalist design', { archetype: 'Specimen', buildId: '1234567890' })
+    const result = _readArchiveHandler(FIXTURES_DIR)
+    expect(result[0].archetype).toBe('Specimen')
+    expect(result[0].buildId).toBe('1234567890')
+  })
+
+  it('defaults archetype and buildId to empty string when missing', () => {
+    writeArchiveEntry('2026-03-14', 'Simple design')
+    const result = _readArchiveHandler(FIXTURES_DIR)
+    expect(result[0].archetype).toBe('')
+    expect(result[0].buildId).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
- **Archive list page** (`/archive`) — shows all past daily builds with archetype name, brief excerpt, and date
- **Archive detail page** (`/archive/$date`) — showcases a single build's design brief, tokens, signals, and rationale
- **Pipeline archiver** — now saves `signals-brief.md`, `preset.ts`, and screenshots per build for future detail pages
- **Education fix** — removed years from education section in timeline
- Removed hardcoded colors from archive pages, uses CSS variable tokens
- Graceful fallback for older builds without new artifacts

## Test plan
- [x] Navigate to `/archive` — see all 14 builds listed with archetype names
- [x] Click a build — detail page shows brief, rationale, "tokens not available", "signals not available"
- [x] Click "Back to Archive" — returns to list
- [x] Navigate to invalid date — error page renders
- [x] Run pipeline — verify new artifacts saved to build directory
- [x] All 121 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)