### PR TITLE
Prompt Inspector: pipeline trace system for dev panel

### DIFF
--- a/app/routes/dev.tsx
+++ b/app/routes/dev.tsx
@@ -2,7 +2,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useState, useRef, useEffect } from 'react'
 import { readSignals, saveOverrides } from '../server/signals'
-import { readArchive, type ArchiveEntry } from '../server/archive'
+import { readArchive, readArchiveDetail, type ArchiveEntry } from '../server/archive'
 
 export const Route = createFileRoute('/dev')({
   loader: async () => {
@@ -136,6 +136,7 @@ function DevPanel() {
   const signals = initialSignals as Signals
 
   const [activePane, setActivePane] = useState<PaneName>('pipeline')
+  const [traceSteps, setTraceSteps] = useState<any[]>([])
 
   const [moodOverride, setMoodOverride] = useState<string>(signals.mood_override ?? '')
   const [notes, setNotes] = useState<string>(signals.notes ?? '')
@@ -179,6 +180,7 @@ function DevPanel() {
     logAccumRef.current = []
     setAttemptNum(1)
     setResult(null)
+    setTraceSteps([])
 
     const es = new EventSource(`/api/pipeline?dryRun=${dryRun}&mock=true`)
     esRef.current = es
@@ -187,6 +189,12 @@ function DevPanel() {
       const event = JSON.parse(e.data) as
         | { type: 'log'; line: string }
         | { type: 'done'; success: boolean; error?: string }
+        | { type: 'trace'; step: any }
+
+      if (event.type === 'trace') {
+        setTraceSteps(prev => [...prev, event.step])
+        return
+      }
 
       if (event.type === 'log') {
         const line = event.line
@@ -319,7 +327,7 @@ function DevPanel() {
             <ArchivePane archive={archive as ArchiveEntry[]} />
           )}
           {activePane === 'inspector' && (
-            <InspectorPane />
+            <InspectorPane traceSteps={traceSteps} archive={archive as ArchiveEntry[]} />
           )}
           {activePane === 'run' && (
             <RunPane
@@ -555,19 +563,193 @@ function ArchivePane({ archive }: { archive: ArchiveEntry[] }) {
   )
 }
 
-// ─── Inspector Pane (placeholder) ─────────────────────────────────────────────
+// ─── Inspector Pane ───────────────────────────────────────────────────────────
 
-function InspectorPane() {
+function InspectorPane({ traceSteps, archive }: { traceSteps: any[], archive: ArchiveEntry[] }) {
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [savedTrace, setSavedTrace] = useState<any[] | null>(null)
+  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set())
+
+  const loadTrace = async (date: string) => {
+    setSelectedDate(date)
+    try {
+      const detail = await readArchiveDetail({ data: date })
+      if (detail?.trace) {
+        const parsed = JSON.parse(detail.trace)
+        setSavedTrace(parsed.steps || [])
+      } else {
+        setSavedTrace([])
+      }
+    } catch {
+      setSavedTrace([])
+    }
+  }
+
+  const displaySteps = selectedDate ? (savedTrace || []) : traceSteps
+  const isLive = !selectedDate && traceSteps.length > 0
+
+  const toggleStep = (idx: number) => {
+    setExpandedSteps(prev => {
+      const next = new Set(prev)
+      next.has(idx) ? next.delete(idx) : next.add(idx)
+      return next
+    })
+  }
+
   return (
     <>
       <div style={{ ...s.sectionLabel, marginBottom: '16px' }}>// PROMPT INSPECTOR</div>
-      <div style={{ background: '#151b23', border: '1px solid #1e2633', borderRadius: '8px', padding: '24px', textAlign: 'center' }}>
-        <div style={{ fontSize: '13px', color: '#6b7b8d', lineHeight: '1.6' }}>
-          Available when agent swarm is active.<br />
-          Shows the prompts sent to each designer agent with token/byte counts.
-        </div>
+
+      {/* Date selector */}
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '20px', flexWrap: 'wrap' }}>
+        <button
+          onClick={() => { setSelectedDate(null); setSavedTrace(null) }}
+          style={{
+            ...s.saveBtn,
+            ...(selectedDate === null ? { color: '#22d3ee', borderColor: '#22d3ee' } : {}),
+          }}
+        >
+          Live
+        </button>
+        {archive.slice(0, 10).map(entry => (
+          <button
+            key={entry.date}
+            onClick={() => loadTrace(entry.date)}
+            style={{
+              ...s.saveBtn,
+              ...(selectedDate === entry.date ? { color: '#22d3ee', borderColor: '#22d3ee' } : {}),
+            }}
+          >
+            {entry.date}
+          </button>
+        ))}
       </div>
+
+      {/* Live indicator */}
+      {isLive && (
+        <div style={{ ...s.badge, marginBottom: '16px' }}>
+          <span style={{ width: '6px', height: '6px', borderRadius: '50%', background: '#f59e0b' }} />
+          streaming {traceSteps.length} steps
+        </div>
+      )}
+
+      {/* Steps */}
+      {displaySteps.length === 0 ? (
+        <div style={{ ...s.signalCard, textAlign: 'center' as const, padding: '40px' }}>
+          <div style={{ fontSize: '13px', color: '#6b7b8d' }}>
+            {selectedDate
+              ? 'No trace data available for this build.'
+              : 'Run the pipeline to see trace data here.'}
+          </div>
+        </div>
+      ) : (
+        displaySteps.map((step: any, i: number) => (
+          <TraceStepCard
+            key={i}
+            step={step}
+            index={i}
+            expanded={expandedSteps.has(i)}
+            onToggle={() => toggleStep(i)}
+          />
+        ))
+      )}
     </>
+  )
+}
+
+function TraceStepCard({ step, index, expanded, onToggle }: {
+  step: any, index: number, expanded: boolean, onToggle: () => void
+}) {
+  const phaseColors: Record<number, string> = {
+    0: '#6b7b8d',
+    1: '#22d3ee',
+    2: '#a78bfa',
+    3: '#f59e0b',
+    4: '#4ade80',
+  }
+  const phaseNames: Record<number, string> = {
+    0: 'SETUP',
+    1: 'DIRECTION',
+    2: 'TOKENS',
+    3: 'DESIGN',
+    4: 'VALIDATION',
+  }
+  const color = phaseColors[step.phase] || '#6b7b8d'
+
+  return (
+    <div
+      style={{
+        background: '#151b23',
+        border: '1px solid #1e2633',
+        borderRadius: '8px',
+        padding: '12px',
+        marginBottom: '8px',
+        cursor: 'pointer',
+        borderLeft: `3px solid ${color}`,
+      }}
+      onClick={onToggle}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <span style={{
+            fontSize: '9px', color, fontWeight: 700,
+            fontFamily: '"Space Mono", monospace',
+            letterSpacing: '0.05em',
+            background: `${color}15`,
+            padding: '2px 6px',
+            borderRadius: '3px',
+          }}>
+            {phaseNames[step.phase] || `P${step.phase}`}
+          </span>
+          <span style={{ fontSize: '13px', color: '#e0e6ed', fontWeight: 600 }}>
+            {step.name}
+          </span>
+          {step.durationMs > 0 && (
+            <span style={{ fontSize: '11px', color: '#6b7b8d' }}>
+              {step.durationMs > 60000
+                ? `${(step.durationMs / 60000).toFixed(1)}m`
+                : step.durationMs > 1000
+                ? `${(step.durationMs / 1000).toFixed(1)}s`
+                : `${step.durationMs}ms`}
+            </span>
+          )}
+        </div>
+        <span style={{ fontSize: '11px', color: '#6b7b8d' }}>
+          {expanded ? '▾' : '▸'}
+        </span>
+      </div>
+
+      {expanded && (
+        <div style={{ marginTop: '12px' }}>
+          {step.input && Object.keys(step.input).length > 0 && (
+            <div style={{ marginBottom: '8px' }}>
+              <div style={{ fontSize: '10px', fontWeight: 600, textTransform: 'uppercase' as const, letterSpacing: '.07em', color: '#6b7b8d', fontFamily: '"Space Mono", monospace', marginBottom: '4px' }}>INPUT</div>
+              <pre style={{
+                fontSize: '11px', color: '#8b98a5', background: '#0e1117',
+                padding: '8px', borderRadius: '4px', overflow: 'auto',
+                maxHeight: '200px', whiteSpace: 'pre-wrap' as const, margin: 0,
+                fontFamily: '"Space Mono", monospace',
+              }}>
+                {JSON.stringify(step.input, null, 2)}
+              </pre>
+            </div>
+          )}
+          {step.output && Object.keys(step.output).length > 0 && (
+            <div>
+              <div style={{ fontSize: '10px', fontWeight: 600, textTransform: 'uppercase' as const, letterSpacing: '.07em', color: '#6b7b8d', fontFamily: '"Space Mono", monospace', marginBottom: '4px' }}>OUTPUT</div>
+              <pre style={{
+                fontSize: '11px', color: '#8b98a5', background: '#0e1117',
+                padding: '8px', borderRadius: '4px', overflow: 'auto',
+                maxHeight: '300px', whiteSpace: 'pre-wrap' as const, margin: 0,
+                fontFamily: '"Space Mono", monospace',
+              }}>
+                {JSON.stringify(step.output, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/app/server/archive-detail-impl.ts
+++ b/app/server/archive-detail-impl.ts
@@ -14,6 +14,7 @@ export interface ArchiveDetail {
   filesChanged: string[]
   hasScreenshot: boolean
   buildId: string
+  trace: string
 }
 
 export function _readArchiveDetail(date: string, archivePath = ARCHIVE_PATH): ArchiveDetail | null {
@@ -40,6 +41,7 @@ export function _readArchiveDetail(date: string, archivePath = ARCHIVE_PATH): Ar
 
   const signalsBrief = buildDir ? readSafe(join(buildDir, 'signals-brief.md')) : ''
   const preset = buildDir ? readSafe(join(buildDir, 'preset.ts')) : ''
+  const trace = buildDir ? readSafe(join(buildDir, 'trace.json')) : ''
   const hasScreenshot = buildDir ? existsSync(join(buildDir, 'screenshot.png')) : false
   const archetype = readSafe(join(dateDir, 'archetype.txt')).trim()
 
@@ -67,6 +69,6 @@ export function _readArchiveDetail(date: string, archivePath = ARCHIVE_PATH): Ar
 
   return {
     date, archetype, brief, signalsBrief, preset,
-    rationale, filesChanged, hasScreenshot, buildId,
+    rationale, filesChanged, hasScreenshot, buildId, trace,
   }
 }

--- a/scripts/design-agents.js
+++ b/scripts/design-agents.js
@@ -32,6 +32,7 @@ import {
 import { backup, writeFiles, restore, ROOT } from './utils/file-manager.js'
 import { validateBuild } from './utils/build-validator.js'
 import { archive } from './utils/archiver.js'
+import { createTrace } from './utils/trace.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -318,7 +319,7 @@ function validateCodegen() {
  * @param {{ signals: object, brief: string, contentSummary: string }} context
  * @returns {Promise<{ rationale: string, design_brief: string, files: Array<{path: string, content: string}> }>}
  */
-export async function runAgentSwarm(context) {
+export async function runAgentSwarm(context, { onTraceStep } = {}) {
   const { signals, brief, contentSummary } = context
 
   // Read creative weights from environment
@@ -329,6 +330,34 @@ export async function runAgentSwarm(context) {
     risk: parseInt(process.env.WEIGHT_RISK || '5'),
   }
   console.log(`  creative weights: signals=${weights.signals} inspiration=${weights.inspiration} ratings=${weights.ratings} risk=${weights.risk}`)
+
+  const trace = createTrace(signals.date || new Date().toISOString().slice(0, 10), {
+    onStep: (step) => {
+      console.log(`[TRACE] ${JSON.stringify(step)}`)
+      onTraceStep?.(step)
+    },
+  })
+
+  async function saveTrace() {
+    try {
+      const archiveDateDir = path.join(ROOT, 'archive', signals.date)
+      const builds = readdirSync(archiveDateDir, { withFileTypes: true })
+        .filter(b => b.isDirectory() && b.name.startsWith('build-'))
+        .sort().reverse()
+      if (builds[0]) {
+        await writeFile(
+          path.join(archiveDateDir, builds[0].name, 'trace.json'),
+          trace.toJSON(),
+          'utf8'
+        )
+        console.log(`  trace saved to ${builds[0].name}/trace.json`)
+      }
+    } catch (err) {
+      console.warn(`  trace save failed (non-blocking): ${err.message}`)
+    }
+  }
+
+  try {
 
   const weightsPrompt = `\n\n## Creative Weights (0-10, set by the site owner)\n\nSignals: ${weights.signals}/10 | Inspiration: ${weights.inspiration}/10 | Ratings: ${weights.ratings}/10 | Risk: ${weights.risk}/10\n\n${weights.risk >= 7 ? 'The owner wants BOLD, EXPERIMENTAL design today. Push boundaries.' : weights.risk <= 3 ? 'The owner wants SAFE, POLISHED design today. Proven patterns.' : ''}${weights.inspiration >= 7 ? '\nDesign references should HEAVILY influence your compositional choices.' : ''}${weights.signals <= 3 ? '\nSignals are background texture only — do NOT let weather or sports drive the design.' : ''}`
 
@@ -484,6 +513,24 @@ export async function runAgentSwarm(context) {
     console.log(`  using references (${references.length} chars)`)
   }
 
+  // Trace: record signals and brief loaded
+  trace.addStep({
+    name: 'signals-loaded',
+    phase: 0,
+    input: { providersAvailable: Object.keys(signals).length },
+    output: signals,
+    durationMs: 0,
+  })
+  if (brief) {
+    trace.addStep({
+      name: 'brief-loaded',
+      phase: 0,
+      input: {},
+      output: { brief: brief.slice(0, 500), charCount: brief.length },
+      durationMs: 0,
+    })
+  }
+
   // -----------------------------------------------------------------------
   // Phase 0: Design Director — produces a visual specification
   // -----------------------------------------------------------------------
@@ -502,10 +549,22 @@ export async function runAgentSwarm(context) {
   let visualSpec = ''
   let chosenArchetype = null
   try {
+    const t0Director = Date.now()
     const directorResult = await callAgent('design-director', directorSystemPrompt, directorUserPrompt)
     visualSpec = directorResult._rawResponse || directorResult.rationale || ''
     chosenArchetype = extractArchetypeFromText(visualSpec)
     console.log(`  visual spec: ${(visualSpec.length / 1024).toFixed(0)}KB${chosenArchetype ? ` | archetype: ${chosenArchetype}` : ''}`)
+    trace.addStep({
+      name: 'design-director',
+      phase: 1,
+      input: { archetypeConstraints: archetypeConstraintPrompt.slice(0, 500) },
+      output: {
+        archetype: chosenArchetype || 'unknown',
+        specLength: visualSpec.length,
+        specPreview: visualSpec.slice(0, 500),
+      },
+      durationMs: Date.now() - t0Director,
+    })
   } catch (err) {
     console.warn(`  Design Director failed (non-blocking): ${err.message}`)
     console.warn('  Proceeding without visual spec — agents will use brief directly')
@@ -522,8 +581,20 @@ export async function runAgentSwarm(context) {
       recentBriefs ? '## Recent Archive Briefs\n' + recentBriefs : '',
     ].filter(Boolean).join('\n\n---\n\n')
 
+    const t0Critic = Date.now()
     const criticResult = await callAgent('spec-critic', specCriticPrompt, criticUserPrompt, null, { model: 'haiku' })
     const rawResponse = criticResult._rawResponse || criticResult.rationale || ''
+
+    trace.addStep({
+      name: 'spec-critic',
+      phase: 1,
+      input: { specLength: visualSpec.length },
+      output: {
+        verdict: rawResponse.includes('REVISE') ? 'REVISE' : 'APPROVED',
+        feedback: rawResponse.slice(0, 500),
+      },
+      durationMs: Date.now() - t0Critic,
+    })
 
     if (rawResponse.includes('REVISE')) {
       const feedback = rawResponse.replace(/===VERDICT===/, '').replace(/===END===/, '').replace('REVISE', '').trim()
@@ -563,6 +634,7 @@ export async function runAgentSwarm(context) {
   })
 
   let tokenResult
+  const t0Token = Date.now()
   try {
     tokenResult = await callAgent('token-designer', tokenSystemPrompt, tokenUserPrompt, null, { model: 'haiku' })
   } catch (err) {
@@ -581,6 +653,17 @@ export async function runAgentSwarm(context) {
 
   // Write token files
   await writeFiles(tokenResult.files)
+
+  trace.addStep({
+    name: 'token-designer',
+    phase: 2,
+    input: { briefLength: tokenBrief.length },
+    output: {
+      files: tokenResult.files.map(f => f.path),
+      rationale: (tokenResult.rationale || '').slice(0, 500),
+    },
+    durationMs: Date.now() - t0Token,
+  })
 
   // Run codegen to regenerate styled-system
   const codegenResult = validateCodegen()
@@ -629,6 +712,7 @@ export async function runAgentSwarm(context) {
     + weightsPrompt
 
   let designerResult
+  const t0Designer = Date.now()
   try {
     designerResult = await callAgent('unified-designer', unifiedDesignerSystemPrompt, designerUserPrompt, null, { timeoutMs: 900000 }) // 15 minutes — writes 15 files
   } catch (err) {
@@ -639,6 +723,17 @@ export async function runAgentSwarm(context) {
 
   // Write all files
   await writeFiles(designerResult.files)
+
+  trace.addStep({
+    name: 'unified-designer',
+    phase: 3,
+    input: { tokenContext: tokenContext.length, briefLength: enrichedBrief.length },
+    output: {
+      files: designerResult.files.map(f => f.path),
+      rationale: (designerResult.rationale || '').slice(0, 500),
+    },
+    durationMs: Date.now() - t0Designer,
+  })
 
   // Verify Layout.tsx was written (critical for the site to function)
   const layoutPath = path.join(ROOT, 'app/components/Layout.tsx')
@@ -652,6 +747,17 @@ export async function runAgentSwarm(context) {
   // -----------------------------------------------------------------------
   console.log('\n[phase-4] Build validation')
   const buildResult = validateBuild()
+
+  trace.addStep({
+    name: 'build-validation',
+    phase: 4,
+    input: {},
+    output: {
+      success: buildResult.success,
+      error: buildResult.success ? undefined : (buildResult.error || '').slice(0, 500),
+    },
+    durationMs: 0,
+  })
 
   if (buildResult.success) {
     console.log('\n=== Build passed! ===')
@@ -674,8 +780,20 @@ export async function runAgentSwarm(context) {
         '![Homepage Screenshot](data:image/png;base64,' + screenshotBuffer.toString('base64') + ')',
       ].filter(Boolean).join('\n\n---\n\n')
 
+      const t0ScreenshotCritic = Date.now()
       const screenshotCriticResult = await callAgent('screenshot-critic', screenshotCriticPrompt, criticUserPrompt)
       const criticResponse = screenshotCriticResult._rawResponse || screenshotCriticResult.rationale || ''
+
+      trace.addStep({
+        name: 'screenshot-critic',
+        phase: 4,
+        input: {},
+        output: {
+          verdict: criticResponse.includes('REVISE') ? 'REVISE' : 'SHIP',
+          feedback: criticResponse.slice(0, 500),
+        },
+        durationMs: Date.now() - t0ScreenshotCritic,
+      })
 
       if (criticResponse.includes('REVISE')) {
         const agentMatch = criticResponse.match(/\*\*Responsible agent:\*\*\s*([\w-]+)/)
@@ -734,6 +852,7 @@ export async function runAgentSwarm(context) {
     const designBrief = tokenResult.design_brief || 'Multi-agent redesign'
 
     await archive(signals.date, signals, rationale, designBrief, changedPaths)
+    await saveTrace()
 
     // Save archetype for future anti-repetition enforcement
     if (chosenArchetype && signals.date) {
@@ -804,6 +923,7 @@ export async function runAgentSwarm(context) {
     const designBrief = tokenResult.design_brief || 'Multi-agent redesign (retry)'
 
     await archive(signals.date, signals, rationale, designBrief, changedPaths)
+    await saveTrace()
 
     // Save archetype for future anti-repetition enforcement
     if (chosenArchetype && signals.date) {
@@ -821,6 +941,10 @@ export async function runAgentSwarm(context) {
   // All retries exhausted — restore everything and throw
   await restore(originalBackup)
   throw new Error(`Build failed after retry. Error:\n${retryBuild.error?.slice(0, 1000)}`)
+
+  } finally {
+    await saveTrace()
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/utils/trace.js
+++ b/scripts/utils/trace.js
@@ -1,0 +1,36 @@
+/**
+ * Pipeline trace collector.
+ * Accumulates step data during a pipeline run for inspection and archiving.
+ *
+ * @param {string} date - pipeline date (YYYY-MM-DD)
+ * @param {{ onStep?: (step: object) => void }} [options]
+ * @returns {object} trace instance
+ */
+export function createTrace(date, options = {}) {
+  const steps = []
+  const startedAt = new Date().toISOString()
+
+  return {
+    get date() { return date },
+    get steps() { return steps },
+    get startedAt() { return startedAt },
+
+    addStep(step) {
+      const entry = {
+        ...step,
+        timestamp: new Date().toISOString(),
+      }
+      steps.push(entry)
+      options.onStep?.(entry)
+    },
+
+    toJSON() {
+      return JSON.stringify({
+        date,
+        startedAt,
+        completedAt: new Date().toISOString(),
+        steps,
+      }, null, 2)
+    },
+  }
+}

--- a/tests/scripts/trace.test.js
+++ b/tests/scripts/trace.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { createTrace } from '../../scripts/utils/trace.js'
+
+describe('trace collector', () => {
+  it('creates a trace with metadata', () => {
+    const trace = createTrace('2026-03-27')
+    expect(trace.date).toBe('2026-03-27')
+    expect(trace.steps).toEqual([])
+    expect(trace.startedAt).toBeDefined()
+  })
+
+  it('records a step with input and output', () => {
+    const trace = createTrace('2026-03-27')
+    trace.addStep({
+      name: 'collect-signals',
+      phase: 0,
+      input: { providers: 19 },
+      output: { weather: { temp_f: 65 }, sports: [{ team: 'Tigers', result: 'W 8-2' }] },
+      durationMs: 3200,
+    })
+    expect(trace.steps).toHaveLength(1)
+    expect(trace.steps[0].name).toBe('collect-signals')
+    expect(trace.steps[0].output.weather.temp_f).toBe(65)
+  })
+
+  it('records multiple steps in order', () => {
+    const trace = createTrace('2026-03-27')
+    trace.addStep({ name: 'signals', phase: 0, input: {}, output: { date: '2026-03-27' }, durationMs: 100 })
+    trace.addStep({ name: 'interpret', phase: 1, input: {}, output: { brief: '...' }, durationMs: 200 })
+    trace.addStep({ name: 'director', phase: 2, input: {}, output: { spec: '...' }, durationMs: 5000 })
+    expect(trace.steps).toHaveLength(3)
+    expect(trace.steps.map(s => s.name)).toEqual(['signals', 'interpret', 'director'])
+  })
+
+  it('calls onStep listener when step is added', () => {
+    const received = []
+    const trace = createTrace('2026-03-27', { onStep: (step) => received.push(step) })
+    trace.addStep({ name: 'test', phase: 0, input: {}, output: {}, durationMs: 0 })
+    expect(received).toHaveLength(1)
+    expect(received[0].name).toBe('test')
+  })
+
+  it('serializes to JSON', () => {
+    const trace = createTrace('2026-03-27')
+    trace.addStep({ name: 'test', phase: 0, input: { x: 1 }, output: { y: 2 }, durationMs: 50 })
+    const json = trace.toJSON()
+    const parsed = JSON.parse(json)
+    expect(parsed.date).toBe('2026-03-27')
+    expect(parsed.steps).toHaveLength(1)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -235,7 +235,16 @@ function pipelineApiPlugin(): Plugin {
           const handleData = (chunk: Buffer) => {
             const lines = chunk.toString().split('\n').filter((l: string) => l.trim())
             for (const line of lines) {
-              broadcastPipeline({ type: 'log', line })
+              if (line.startsWith('[TRACE] ')) {
+                try {
+                  const step = JSON.parse(line.slice('[TRACE] '.length))
+                  broadcastPipeline({ type: 'trace', step })
+                } catch {
+                  broadcastPipeline({ type: 'log', line })
+                }
+              } else {
+                broadcastPipeline({ type: 'log', line })
+              }
             }
           }
 


### PR DESCRIPTION
## Summary
- **Trace collector** (`scripts/utils/trace.js`) — accumulates pipeline step data with timing, saves as JSON
- **Pipeline instrumentation** — 8 trace steps emitted at each phase (signals, brief, director, spec-critic, token-designer, unified-designer, build-validation, screenshot-critic) with real timing data
- **SSE forwarding** — `[TRACE]` lines from pipeline stdout parsed and forwarded as `{ type: 'trace', step }` events via existing SSE endpoint
- **Inspector pane** — replaces dev panel placeholder with full trace viewer: live streaming during runs + browse saved traces from past builds
- **Archive integration** — `trace.json` saved per build, readable via archive detail API
- **Error resilience** — `try/finally` saves partial traces even on pipeline failure

## Test plan
- [x] All 126 tests pass (5 new trace collector tests)
- [x] Open dev panel → Prompt Inspector → shows "Run the pipeline to see trace data here"
- [x] Run a pipeline → trace steps appear in real-time with phase colors and timing
- [x] After run, click a date button → loads saved trace from archive
- [x] Each step card expands to show input/output JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)