### PR TITLE
Fix Vercel build: add packageManager for pnpm 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/daily-redesign.yml
+++ b/.github/workflows/daily-redesign.yml
@@ -23,8 +23,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dougmarch",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.14.0",
   "imports": {
     "#/*": "./app/*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,7 @@ settings:
 overrides:
   picomatch: '>=4.0.4'
   brace-expansion: '>=5.0.5'
-  h3@^2: 2.0.1-rc.20
-  h3@^1: '>=1.15.9'
+  h3: '>=1.15.9'
   srvx: '>=0.11.13'
   serialize-javascript: '>=7.0.3'
   undici: '>=7.24.0'


### PR DESCRIPTION
## Summary
Vercel defaults to pnpm 9 which can't read lockfiles generated by pnpm 10, causing `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Adding `packageManager: "pnpm@10.14.0"` tells Vercel to use the correct version via corepack.

## Test plan
- [ ] CI passes (unit + e2e)
- [ ] Vercel preview deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)