### PR TITLE
Fix: detect and remove fake ScrollRestoration/Scripts definitions

### DIFF
--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -1,5 +1,5 @@
 import '../styles/panda.css'
-import { createRootRoute, Link, Outlet, HeadContent } from '@tanstack/react-router'
+import { createRootRoute, Link, Outlet, HeadContent, ScrollRestoration, Scripts } from '@tanstack/react-router'
 import { Layout } from '../components/Layout'
 import { styled } from '../../styled-system/jsx'
 
@@ -72,10 +72,3 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   )
 }
 
-function ScrollRestoration() {
-  return null
-}
-
-function Scripts() {
-  return null
-}

--- a/scripts/design-agents.js
+++ b/scripts/design-agents.js
@@ -656,41 +656,52 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
 
   // Post-write fixup: ensure __root.tsx has critical imports for SPA hydration.
   // The token designer frequently drops ScrollRestoration and Scripts imports,
-  // which prevents the client JS bundle from loading (site renders server HTML only).
+  // or defines fake local versions (return null). Both break client-side hydration.
   try {
     const rootPath = path.join(ROOT, 'app/routes/__root.tsx')
     let rootContent = await readFile(rootPath, 'utf8')
+    let fixed = false
+
+    // Step 1: Check if ScrollRestoration/Scripts are in the @tanstack/react-router import line
+    const routerImportMatch = rootContent.match(/import\s*\{([^}]+)\}\s*from\s*['"]@tanstack\/react-router['"]/)
+    const routerImports = routerImportMatch ? routerImportMatch[1] : ''
     const requiredImports = ['ScrollRestoration', 'Scripts']
-    const missing = requiredImports.filter(name => !rootContent.includes(name))
-    if (missing.length > 0) {
-      // Add missing imports to the @tanstack/react-router import line
+    const missingFromImport = requiredImports.filter(name => !routerImports.includes(name))
+
+    if (missingFromImport.length > 0) {
+      // Add missing to the import line
       rootContent = rootContent.replace(
         /import\s*\{([^}]+)\}\s*from\s*['"]@tanstack\/react-router['"]/,
         (match, imports) => {
           const existing = imports.split(',').map(s => s.trim())
-          const merged = [...new Set([...existing, ...missing])]
+          const merged = [...new Set([...existing, ...missingFromImport])]
           return `import { ${merged.join(', ')} } from '@tanstack/react-router'`
         }
       )
-      // Ensure ScrollRestoration and Scripts are in the JSX body.
-      // The token designer produces varying structures, so try multiple patterns:
-      //   1. </Layout> ... </> (fragment wrapper)
-      //   2. {children} ... </body> (html/body wrapper)
-      //   3. {children} ... </> (any wrapper)
-      if (!rootContent.includes('<ScrollRestoration')) {
-        const inserted = rootContent
-          .replace(/(\{children\})([\s\S]*?)(<\/body>)/, '$1\n        <ScrollRestoration />\n        <Scripts />$2$3')
-        if (inserted !== rootContent) {
-          rootContent = inserted
-        } else {
-          // Fallback: insert before the last closing tag pair
-          rootContent = rootContent
-            .replace(/(\{children\}<\/Layout>)([\s\S]*?)(\s*<\/>)/, '$1\n    <ScrollRestoration />\n    <Scripts />$2$3')
-            .replace(/(<\/Layout>)([\s\S]*?)(\s*<\/>)/, '$1\n    <ScrollRestoration />\n    <Scripts />$2$3')
-        }
+      fixed = true
+    }
+
+    // Step 2: Remove fake local definitions (function ScrollRestoration/Scripts that return null)
+    rootContent = rootContent.replace(/\nfunction ScrollRestoration\(\)\s*\{[\s\S]*?return\s+null[\s\S]*?\}\n?/g, '\n')
+    rootContent = rootContent.replace(/\nfunction Scripts\(\)\s*\{[\s\S]*?return\s+null[\s\S]*?\}\n?/g, '\n')
+
+    // Step 3: Ensure ScrollRestoration and Scripts are in the JSX body
+    if (!rootContent.includes('<ScrollRestoration')) {
+      const inserted = rootContent
+        .replace(/(\{children\})([\s\S]*?)(<\/body>)/, '$1\n        <ScrollRestoration />\n        <Scripts />$2$3')
+      if (inserted !== rootContent) {
+        rootContent = inserted
+      } else {
+        rootContent = rootContent
+          .replace(/(\{children\}<\/Layout>)([\s\S]*?)(\s*<\/>)/, '$1\n    <ScrollRestoration />\n    <Scripts />$2$3')
+          .replace(/(<\/Layout>)([\s\S]*?)(\s*<\/>)/, '$1\n    <ScrollRestoration />\n    <Scripts />$2$3')
       }
+      fixed = true
+    }
+
+    if (fixed) {
       await writeFile(rootPath, rootContent, 'utf8')
-      console.log(`  [fixup] added missing imports to __root.tsx: ${missing.join(', ')}`)
+      console.log(`  [fixup] fixed __root.tsx: ensured ScrollRestoration/Scripts are imported from @tanstack/react-router`)
     }
   } catch (err) {
     console.warn(`  [fixup] __root.tsx fixup failed (non-blocking): ${err.message}`)

--- a/scripts/prompts/unified-designer.md
+++ b/scripts/prompts/unified-designer.md
@@ -11,8 +11,21 @@ A personal portfolio for Doug March — Product Designer & Developer. The site h
 **Identity:**
 - Name: "Doug March"
 - Role: "Product Designer & Developer"
+- Logo: `import logoSvg from '../assets/logo.svg'` — render as `<img src={logoSvg} />`. Use the logo in the navigation area. It's a green circle target + blue hook shape. Size and placement should match the archetype.
 - Navigation: Home (/), About (/about)
-- Footer: Include a small "Archive" link to /archive somewhere in the footer area of the page. It should not stand out — it should feel like a natural, understated part of whatever content it sits near. Same typographic treatment as surrounding footer text, no special emphasis.
+- Footer: Include a small "Archive" link to /archive somewhere in the footer area. Same typographic treatment as surrounding text, no special emphasis.
+
+**Navigation & Footer — VARY THESE with each archetype:**
+The navigation and footer should feel like part of the day's design, not a static component pasted on top. Examples:
+- **Poster**: Logo large and centered, nav as tiny corner links, footer barely visible
+- **Broadsheet**: Masthead with logo + name, nav as section labels, footer as a colophon with date
+- **Specimen**: Logo as a small annotated artifact, nav as catalog tabs, footer as a label strip
+- **Split**: Logo on one half, nav on the other, footer spanning the divide
+- **Scroll**: Logo fixed in corner as you scroll, nav as floating pills, footer as a full-width band
+- **Index**: Logo inline with the first row, nav as table headers, footer as a data row
+- **Gallery Wall**: Logo mounted on the wall like an exhibit label, nav as gallery room names
+- **Stack**: Logo in the first band, nav as band labels, footer as the final band
+Do NOT just render a horizontal bar with links every day. The nav and footer are design surfaces.
 
 **Portfolio (the primary content — this is a portfolio site):**
 - One featured project (Spaceman) — title, problem statement, external link
@@ -50,7 +63,7 @@ You MUST produce these files. You may organize the code however you want — inl
 
 **Required (framework needs these):**
 - `app/components/Layout.tsx` — root wrapper. Must use named export `export function Layout(...)`. Imports and renders your navigation component. Wraps `{children}`.
-- `app/components/Sidebar.tsx` — navigation element. Layout imports this. Can be a header bar, sidebar, floating nav, bottom bar — whatever fits the composition.
+- `app/components/Sidebar.tsx` — navigation element. Layout imports this. This should change dramatically with each archetype — masthead, sidebar, floating nav, bottom bar, corner mark, overlay menu, tab strip. Import the logo: `import logoSvg from '../assets/logo.svg'`.
 - `app/routes/index.tsx` — home page
 - `app/routes/about.tsx` — about page
 - `app/routes/work.$slug.tsx` — project detail page


### PR DESCRIPTION
## Summary
The site was blank again — this time because the token designer defined **local no-op functions** for `ScrollRestoration` and `Scripts` (`function ScrollRestoration() { return null }`) instead of importing them from `@tanstack/react-router`.

The previous fixup checked `rootContent.includes('ScrollRestoration')` which returned true because the word existed — but as a fake local function, not the real import.

**Fix (3 steps):**
1. Check the `@tanstack/react-router` **import line** specifically, not just file content
2. Remove any fake local `function ScrollRestoration/Scripts` definitions
3. Add the real imports if missing

## Root cause pattern
This is the third variant of this bug:
- v1: Missing imports entirely
- v2: Missing JSX tags (different DOM structure)  
- v3: Fake local definitions (this one)

## Test plan
- [ ] All 130 tests pass
- [ ] Site renders content after deploy
- [ ] Tomorrow's pipeline produces a working site

🤖 Generated with [Claude Code](https://claude.com/claude-code)