### PR TITLE
fix: restore <Scripts /> and add build validator check

### DIFF
--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -1,5 +1,5 @@
 import '../styles/panda.css'
-import { createRootRoute, Link, Outlet, HeadContent } from '@tanstack/react-router'
+import { createRootRoute, Link, Outlet, HeadContent, Scripts } from '@tanstack/react-router'
 import { Layout } from '../components/Layout'
 import { styled } from '../../styled-system/jsx'
 
@@ -67,6 +67,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         {children}
+        <Scripts />
       </body>
     </html>
   )

--- a/scripts/utils/build-validator.js
+++ b/scripts/utils/build-validator.js
@@ -97,7 +97,16 @@ export function validateGenerated() {
     }
   }
 
-  // Check 3: Route files must NOT import or use Layout
+  // Check 3: __root.tsx must render <Scripts /> in the body
+  // Without it, client JS never loads and all route content renders empty
+  try {
+    const rootContent = readFileSync(resolve(ROOT, 'app/routes/__root.tsx'), 'utf8')
+    if (!rootContent.includes('Scripts')) {
+      errors.push('app/routes/__root.tsx: missing <Scripts /> — client JS will not load and routes will render empty. Import Scripts from @tanstack/react-router and render it in the body.')
+    }
+  } catch {}
+
+  // Check 4: Route files must NOT import or use Layout
   // __root.tsx already wraps all routes in <Layout> — importing it again creates double headers
   const routeFiles = [
     'app/routes/index.tsx',


### PR DESCRIPTION
## Summary
- The daily redesign pipeline dropped `<Scripts />` from `__root.tsx`, preventing client JS from loading — the site rendered only header/footer with empty content
- Restores the missing `Scripts` import and `<Scripts />` render in the document body
- Adds a pre-build validation check (`Check 3`) in `build-validator.js` so the pipeline rejects any future redesign that drops `<Scripts />`

## Test plan
- [x] Verified site renders full content (work, leaderboard, signals) with fix applied
- [x] Verified `validateGenerated()` passes with `Scripts` present
- [x] Verified `validateGenerated()` fails when `Scripts` is removed
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)