### PR TITLE
fix: make archive feature work in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ references/*.png
 references/*.jpg
 references/*.jpeg
 
+# Generated archive JSON (built from archive/ at build time)
+public/archive/index.json
+public/archive/*/detail.json
+
 # Build/pipeline artifacts
 test-results/
 themes/

--- a/app/routes/archive.$date.tsx
+++ b/app/routes/archive.$date.tsx
@@ -1,10 +1,23 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
-import { readArchiveDetail } from '../server/archive'
+
+export interface ArchiveDetail {
+  date: string
+  archetype: string
+  brief: string
+  signalsBrief: string
+  preset: string
+  rationale: string
+  filesChanged: string[]
+  hasScreenshot: boolean
+  buildId: string
+  trace: string
+}
 
 export const Route = createFileRoute('/archive/$date')({
   loader: async ({ params }) => {
-    const detail = await readArchiveDetail({ data: params.date })
-    if (!detail) throw new Error('Archive entry not found')
+    const res = await fetch(`/archive/${params.date}/detail.json`)
+    if (!res.ok) throw new Error('Archive entry not found')
+    const detail: ArchiveDetail = await res.json()
     return { detail }
   },
   component: ArchiveDetailPage,

--- a/app/routes/archive.$date.tsx
+++ b/app/routes/archive.$date.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
+import { createFileRoute, Link, useParams } from '@tanstack/react-router'
+import { useState, useEffect } from 'react'
 
 export interface ArchiveDetail {
   date: string
@@ -14,32 +15,7 @@ export interface ArchiveDetail {
 }
 
 export const Route = createFileRoute('/archive/$date')({
-  loader: async ({ params }) => {
-    const res = await fetch(`/archive/${params.date}/detail.json`)
-    if (!res.ok) throw new Error('Archive entry not found')
-    const detail: ArchiveDetail = await res.json()
-    return { detail }
-  },
   component: ArchiveDetailPage,
-  errorComponent: () => (
-    <div style={{ padding: '80px 48px', maxWidth: 800, margin: '0 auto' }}>
-      <h2
-        style={{
-          fontSize: '1.5rem',
-          marginBottom: 16,
-          color: 'var(--colors-text, #111)',
-        }}
-      >
-        Archive entry not found
-      </h2>
-      <Link
-        to="/archive"
-        style={{ color: 'var(--colors-accent, #666)', textDecoration: 'none' }}
-      >
-        ← Back to Archive
-      </Link>
-    </div>
-  ),
 })
 
 /* ---------------------------------------------------------------------------
@@ -146,7 +122,32 @@ function formatDate(date: string): string {
  * ------------------------------------------------------------------------- */
 
 function ArchiveDetailPage() {
-  const { detail } = Route.useLoaderData()
+  const { date } = Route.useParams()
+  const [detail, setDetail] = useState<ArchiveDetail | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    fetch(`/archive/${date}/detail.json`)
+      .then(res => res.ok ? res.json() : null)
+      .then(data => { if (data) setDetail(data); else setError(true) })
+      .catch(() => setError(true))
+  }, [date])
+
+  if (error) {
+    return (
+      <div style={{ padding: '80px 48px', maxWidth: 800, margin: '0 auto' }}>
+        <h2 style={{ fontSize: '1.5rem', marginBottom: 16, color: 'var(--colors-text, #111)' }}>
+          Archive entry not found
+        </h2>
+        <Link to="/archive" style={{ color: 'var(--colors-accent, #666)', textDecoration: 'none' }}>
+          ← Back to Archive
+        </Link>
+      </div>
+    )
+  }
+
+  if (!detail) return null
+
   const tokens = detail.preset ? parsePreset(detail.preset) : null
   const signals = detail.signalsBrief ? parseSignals(detail.signalsBrief) : null
 

--- a/app/routes/archive.tsx
+++ b/app/routes/archive.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link, Outlet, useMatch } from '@tanstack/react-router'
+import { useState, useEffect } from 'react'
 
 export interface ArchiveEntry {
   date: string
@@ -10,12 +11,6 @@ export interface ArchiveEntry {
 }
 
 export const Route = createFileRoute('/archive')({
-  loader: async () => {
-    const res = await fetch('/archive/index.json')
-    if (!res.ok) return { entries: [] as ArchiveEntry[] }
-    const entries: ArchiveEntry[] = await res.json()
-    return { entries }
-  },
   component: ArchivePage,
 })
 
@@ -25,8 +20,16 @@ function truncate(text: string, max: number) {
 }
 
 function ArchivePage() {
-  const { entries } = Route.useLoaderData()
+  const [entries, setEntries] = useState<ArchiveEntry[]>([])
+  const [loaded, setLoaded] = useState(false)
   const childMatch = useMatch({ from: '/archive/$date', shouldThrow: false })
+
+  useEffect(() => {
+    fetch('/archive/index.json')
+      .then(res => res.ok ? res.json() : [])
+      .then(data => { setEntries(data); setLoaded(true) })
+      .catch(() => setLoaded(true))
+  }, [])
 
   // If a child route is active, render only the child (Outlet)
   if (childMatch) {

--- a/app/routes/archive.tsx
+++ b/app/routes/archive.tsx
@@ -1,9 +1,19 @@
 import { createFileRoute, Link, Outlet, useMatch } from '@tanstack/react-router'
-import { readArchive, type ArchiveEntry } from '../server/archive'
+
+export interface ArchiveEntry {
+  date: string
+  brief: string
+  rationale: string
+  filesChanged: string[]
+  archetype: string
+  buildId: string
+}
 
 export const Route = createFileRoute('/archive')({
   loader: async () => {
-    const entries = await readArchive()
+    const res = await fetch('/archive/index.json')
+    if (!res.ok) return { entries: [] as ArchiveEntry[] }
+    const entries: ArchiveEntry[] = await res.json()
     return { entries }
   },
   component: ArchivePage,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "panda codegen && vite",
-    "build": "panda codegen && vite build",
+    "build": "panda codegen && node scripts/generate-archive-json.js && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "test:e2e:site": "playwright test --project=site-health",

--- a/scripts/generate-archive-json.js
+++ b/scripts/generate-archive-json.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+/**
+ * Generate static JSON files for the archive feature.
+ *
+ * Produces:
+ *   public/archive/index.json        — list of all archive entries
+ *   public/archive/{date}/detail.json — per-date detail data
+ *
+ * Run as part of the build step so the SPA can fetch archive data
+ * without server functions.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
+import { resolve, join } from 'path'
+
+const ROOT = resolve(import.meta.dirname, '..')
+const ARCHIVE_PATH = resolve(ROOT, 'archive')
+const PUBLIC_ARCHIVE = resolve(ROOT, 'public', 'archive')
+
+function readSafe(p) {
+  return existsSync(p) ? readFileSync(p, 'utf8') : ''
+}
+
+function generateIndex() {
+  if (!existsSync(ARCHIVE_PATH)) return []
+
+  return readdirSync(ARCHIVE_PATH, { withFileTypes: true })
+    .filter(d => d.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(d.name))
+    .map(d => {
+      const dateDir = join(ARCHIVE_PATH, d.name)
+
+      const archetypePath = join(dateDir, 'archetype.txt')
+      const archetype = existsSync(archetypePath)
+        ? readFileSync(archetypePath, 'utf8').trim()
+        : ''
+
+      const builds = readdirSync(dateDir, { withFileTypes: true })
+        .filter(b => b.isDirectory() && b.name.startsWith('build-'))
+        .map(b => b.name)
+        .sort()
+        .reverse()
+      const latestBuild = builds[0]
+      const buildId = latestBuild?.replace('build-', '') ?? ''
+
+      const briefPath = latestBuild
+        ? join(dateDir, latestBuild, 'brief.md')
+        : join(dateDir, 'brief.md')
+      if (!existsSync(briefPath)) return null
+      const content = readFileSync(briefPath, 'utf8')
+      const lines = content.split('\n')
+      const dateLine = lines.find(l => l.startsWith('# '))
+      const briefLine = lines.find(l => l.startsWith('**Design Brief:** '))
+      if (!dateLine || !briefLine) return null
+
+      let rationale = ''
+      const rationaleStart = lines.findIndex(l => l.startsWith("## Claude's Rationale"))
+      const filesChangedStart = lines.findIndex(l => l.startsWith('## Files Changed'))
+      if (rationaleStart !== -1 && filesChangedStart !== -1) {
+        rationale = lines.slice(rationaleStart + 1, filesChangedStart).join('\n').trim()
+      } else if (rationaleStart !== -1) {
+        rationale = lines.slice(rationaleStart + 1).join('\n').trim()
+      }
+
+      const filesChanged = []
+      if (filesChangedStart !== -1) {
+        for (let i = filesChangedStart + 1; i < lines.length; i++) {
+          const line = lines[i].trim()
+          if (line.startsWith('- ')) filesChanged.push(line.slice(2).trim())
+        }
+      }
+
+      return {
+        date: dateLine.slice(2).trim(),
+        brief: briefLine.slice('**Design Brief:** '.length).trim(),
+        rationale,
+        filesChanged,
+        archetype,
+        buildId,
+      }
+    })
+    .filter(e => e !== null)
+    .sort((a, b) => b.date.localeCompare(a.date))
+}
+
+function generateDetail(date) {
+  const dateDir = join(ARCHIVE_PATH, date)
+  if (!existsSync(dateDir)) return null
+
+  const builds = readdirSync(dateDir, { withFileTypes: true })
+    .filter(b => b.isDirectory() && b.name.startsWith('build-'))
+    .map(b => b.name)
+    .sort()
+    .reverse()
+  const latestBuild = builds[0]
+  const buildDir = latestBuild ? join(dateDir, latestBuild) : null
+  const buildId = latestBuild?.replace('build-', '') ?? ''
+
+  const briefContent = buildDir
+    ? readSafe(join(buildDir, 'brief.md'))
+    : readSafe(join(dateDir, 'brief.md'))
+
+  const signalsBrief = buildDir ? readSafe(join(buildDir, 'signals-brief.md')) : ''
+  const preset = buildDir ? readSafe(join(buildDir, 'preset.ts')) : ''
+  const trace = buildDir ? readSafe(join(buildDir, 'trace.json')) : ''
+  const hasScreenshot = existsSync(join(PUBLIC_ARCHIVE, `${date}.png`))
+  const archetype = readSafe(join(dateDir, 'archetype.txt')).trim()
+
+  const lines = briefContent.split('\n')
+  const briefLine = lines.find(l => l.startsWith('**Design Brief:** '))
+  const brief = briefLine?.slice('**Design Brief:** '.length).trim() ?? ''
+
+  let rationale = ''
+  const rationaleStart = lines.findIndex(l => l.startsWith("## Claude's Rationale"))
+  const filesChangedStart = lines.findIndex(l => l.startsWith('## Files Changed'))
+  if (rationaleStart !== -1 && filesChangedStart !== -1) {
+    rationale = lines.slice(rationaleStart + 1, filesChangedStart).join('\n').trim()
+  } else if (rationaleStart !== -1) {
+    rationale = lines.slice(rationaleStart + 1).join('\n').trim()
+  }
+
+  const filesChanged = []
+  if (filesChangedStart !== -1) {
+    for (let i = filesChangedStart + 1; i < lines.length; i++) {
+      const line = lines[i].trim()
+      if (line.startsWith('- ')) filesChanged.push(line.slice(2).trim())
+    }
+  }
+
+  return {
+    date, archetype, brief, signalsBrief, preset,
+    rationale, filesChanged, hasScreenshot, buildId, trace,
+  }
+}
+
+// Main
+console.log('[generate-archive-json] Generating static archive data...')
+
+const entries = generateIndex()
+console.log(`  found ${entries.length} archive entries`)
+
+// Write index.json
+mkdirSync(PUBLIC_ARCHIVE, { recursive: true })
+writeFileSync(
+  join(PUBLIC_ARCHIVE, 'index.json'),
+  JSON.stringify(entries),
+  'utf8'
+)
+console.log('  wrote public/archive/index.json')
+
+// Write per-date detail.json
+let detailCount = 0
+for (const entry of entries) {
+  const detail = generateDetail(entry.date)
+  if (detail) {
+    const dateDir = join(PUBLIC_ARCHIVE, entry.date)
+    mkdirSync(dateDir, { recursive: true })
+    writeFileSync(
+      join(dateDir, 'detail.json'),
+      JSON.stringify(detail),
+      'utf8'
+    )
+    detailCount++
+  }
+}
+console.log(`  wrote ${detailCount} detail.json files`)
+console.log('[generate-archive-json] Done')


### PR DESCRIPTION
## Summary
- The archive routes used server functions (`fs.readdir`/`readFile`) that work in dev but fail in production — the app deploys as a static SPA to Vercel with no Node.js server
- Added `scripts/generate-archive-json.js` that runs at build time to produce `public/archive/index.json` and per-date `detail.json` files
- Updated archive route loaders to `fetch()` these static JSON files instead of calling server functions
- Added the generate step to the `build` script in package.json

## Test plan
- [x] `pnpm build` generates archive JSON files in `dist/client/archive/`
- [x] 130 unit tests pass
- [x] 21/21 e2e tests pass including archive list and detail page tests
- [x] Archive list loads entries from static JSON in preview mode
- [x] Archive detail pages load per-date data from static JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)