### PR TITLE
fix: override hono to resolve 6 dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
       "undici": ">=7.24.0",
       "node-forge": ">=1.4.0",
       "path-to-regexp": ">=8.4.0",
-      "esbuild": ">=0.25.0"
+      "esbuild": ">=0.25.0",
+      "hono": ">=4.12.12",
+      "@hono/node-server": ">=1.19.13"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,8 @@ overrides:
   node-forge: '>=1.4.0'
   path-to-regexp: '>=8.4.0'
   esbuild: '>=0.25.0'
+  hono: '>=4.12.12'
+  '@hono/node-server': '>=1.19.13'
 
 importers:
 
@@ -466,11 +468,11 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.12'
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
@@ -2112,8 +2114,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.7:
-    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -4031,9 +4033,9 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.7)':
+  '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
-      hono: 4.12.7
+      hono: 4.12.12
 
   '@ioredis/commands@1.5.1': {}
 
@@ -4089,7 +4091,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.7)
+      '@hono/node-server': 1.19.13(hono@4.12.12)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4099,7 +4101,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.7
+      hono: 4.12.12
       jose: 6.2.1
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5971,7 +5973,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.7: {}
+  hono@4.12.12: {}
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
## Summary
- Dependabot can't update `hono` because pnpm doesn't support updating transitive dependencies
- Adds pnpm overrides for `hono >=4.12.12` and `@hono/node-server >=1.19.13`
- Resolves all 6 open dependabot alerts (all medium severity, via `@pandacss/dev → @pandacss/mcp → @modelcontextprotocol/sdk`)
- `pnpm audit` reports 0 vulnerabilities

## Test plan
- [x] `pnpm audit` — 0 vulnerabilities
- [x] 130 unit tests pass
- [x] 21/21 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)