### PR TITLE
fix: increase daily redesign job timeout to 45 minutes

### DIFF
--- a/.github/workflows/daily-redesign.yml
+++ b/.github/workflows/daily-redesign.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   redesign:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary
- Today's daily redesign was cancelled because the unified-designer agent exceeded the 30-minute job timeout
- The agent itself allows up to 30 min, but by the time it starts (~8 min into the job), only ~22 min remain
- Bumps job timeout from 30 → 45 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)