### PR TITLE
fix: pipeline reliability and security improvements

### DIFF
--- a/app/server/signals.ts
+++ b/app/server/signals.ts
@@ -7,7 +7,14 @@ export const readSignals = createServerFn({ method: 'GET' })
   .handler(() => _readSignalsHandler())
 
 export const saveOverrides = createServerFn({ method: 'POST' })
-  .inputValidator((d: unknown) => d as { moodOverride: string | null; notes: string | null })
+  .inputValidator((d: unknown) => {
+    const obj = d as Record<string, unknown>
+    if (typeof obj !== 'object' || obj === null) throw new Error('Invalid input')
+    return {
+      moodOverride: obj.moodOverride === null ? null : String(obj.moodOverride ?? ''),
+      notes: obj.notes === null ? null : String(obj.notes ?? ''),
+    }
+  })
   .handler(({ data }) => {
     _saveOverridesHandler(data)
     return { ok: true }

--- a/scripts/daily-redesign.js
+++ b/scripts/daily-redesign.js
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'url'
 import path from 'path'
 config({ path: path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../.env') })
 
-import { execSync, spawnSync } from 'child_process'
+import { execSync } from 'child_process'
 import { readFile } from 'fs/promises'
 import { existsSync } from 'fs'
 import { callClaudeCLI as callClaudeCLIShared } from './utils/claude-cli.js'
@@ -235,21 +235,6 @@ function extractToolUse(response) {
     toolUseId: toolUseBlock.id,
     input: toolUseBlock.input,
   }
-}
-
-/**
- * Commit the generated files to git.
- * Configures git identity (required in GitHub Actions), stages all, commits.
- * @param {string} date
- * @param {string} designBrief
- */
-function gitCommit(date, designBrief) {
-  execSync('git config user.name "Daily Redesign"', { cwd: ROOT })
-  execSync('git config user.email "redesign@doug-march.com"', { cwd: ROOT })
-  execSync('git add -A', { cwd: ROOT })
-  const msg = `design(${date}): ${designBrief}`
-  spawnSync('git', ['commit', '-m', msg], { cwd: ROOT, stdio: 'inherit' })
-  console.log(`  committed: ${msg}`)
 }
 
 async function main() {

--- a/scripts/design-agents.js
+++ b/scripts/design-agents.js
@@ -53,16 +53,36 @@ export const FILE_OWNERSHIP = Object.fromEntries([
 const ARCHETYPE_NAMES = ['Gallery Wall', 'Broadsheet', 'Specimen', 'Poster', 'Scroll', 'Split', 'Stack', 'Index']
 
 /**
- * Extract the first archetype name found in a block of text.
+ * Extract the chosen archetype from a visual spec or block of text.
+ *
+ * First tries to match the structured declaration line (e.g., "**Archetype:** The Broadsheet").
+ * Falls back to finding the last archetype mention in the text, which avoids
+ * false matches from the forbidden-archetype constraint block that appears early.
+ *
  * @param {string} text
  * @returns {string|null}
  */
 export function extractArchetypeFromText(text) {
+  // Strategy 1: Match the structured "**Archetype:**" declaration line
   for (const name of ARCHETYPE_NAMES) {
-    const pattern = new RegExp(`\\b${name.replace(' ', '\\s+')}\\b`, 'i')
+    const pattern = new RegExp(`\\*\\*Archetype:\\*\\*\\s*(?:The\\s+)?${name.replace(' ', '\\s+')}`, 'i')
     if (pattern.test(text)) return name
   }
-  return null
+
+  // Strategy 2: Find the last mention of any archetype name in the text.
+  // The chosen archetype appears in the spec body; forbidden names appear
+  // earlier in the echoed constraint block.
+  let latest = null
+  for (const name of ARCHETYPE_NAMES) {
+    const pattern = new RegExp(`\\b${name.replace(' ', '\\s+')}\\b`, 'gi')
+    let m
+    while ((m = pattern.exec(text)) !== null) {
+      if (!latest || m.index > latest.index) {
+        latest = { name, index: m.index }
+      }
+    }
+  }
+  return latest?.name ?? null
 }
 
 /**
@@ -167,9 +187,8 @@ export function identifyFailingAgent(errorOutput) {
   }
 
   if (agents.size === 0) return 'both'
-  if (agents.has('token-designer')) return 'token-designer'
-  if (agents.size === 1) return [...agents][0]
-  return 'both'
+  if (agents.size === 2) return 'both'
+  return [...agents][0]
 }
 
 // ---------------------------------------------------------------------------
@@ -577,6 +596,7 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
     console.log('\n[spec-critic] Reviewing visual spec...')
     const criticUserPrompt = [
       '## Structured Brief\n\n' + brief,
+      archetypeConstraintPrompt ? '## Archetype Constraints\n' + archetypeConstraintPrompt : '',
       '## Visual Specification\n\n' + visualSpec,
       recentBriefs ? '## Recent Archive Briefs\n' + recentBriefs : '',
     ].filter(Boolean).join('\n\n---\n\n')
@@ -956,6 +976,9 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
     try {
       const retryResult = await callAgent(agent, config.prompt, config.user(), buildResult.error)
       await writeFiles(retryResult.files)
+      // Update the result so the archive records the retry output, not stale originals
+      if (agent === 'token-designer') tokenResult = retryResult
+      if (agent === 'unified-designer') designerResult = retryResult
     } catch (err) {
       console.error(`  ${agent} retry failed: ${err.message}`)
     }

--- a/scripts/signals/market.js
+++ b/scripts/signals/market.js
@@ -12,6 +12,9 @@ export async function collect(_profile) {
   const json = await res.json()
 
   const quote = json['Global Quote']
+  if (!quote || !quote['05. price']) {
+    throw new Error('Alpha Vantage returned no quote data (rate limit or market closed)')
+  }
   const price = quote['05. price']
   const change = quote['09. change']
   const change_percent = quote['10. change percent']

--- a/scripts/utils/claude-cli.js
+++ b/scripts/utils/claude-cli.js
@@ -81,6 +81,7 @@ export async function callClaudeCLI(agentName, systemPrompt, promptText, options
     let stderr = ''
     let lineBuffer = ''   // Buffer for incomplete JSON lines
     let charCount = 0     // Track characters received for progress
+    let lastOutputTime = Date.now()  // Track last output for stall detection
 
     // Pipe the prompt file to stdin, ignoring EPIPE if the child exits early
     const promptStream = createReadStream(promptPath)
@@ -88,6 +89,7 @@ export async function callClaudeCLI(agentName, systemPrompt, promptText, options
     promptStream.pipe(child.stdin)
 
     child.stdout.on('data', (chunk) => {
+      lastOutputTime = Date.now()
       lineBuffer += chunk.toString()
       const lines = lineBuffer.split('\n')
       // Keep the last incomplete line in the buffer
@@ -134,8 +136,21 @@ export async function callClaudeCLI(agentName, systemPrompt, promptText, options
       reject(new Error(`[${agentName}] timed out after ${Math.round(timeoutMs / 60000)} minutes (generated ${(charCount / 1024).toFixed(0)}KB before timeout)${extra}`))
     }, timeoutMs)
 
+    // Stall detection: kill if no output for 5 minutes
+    const STALL_TIMEOUT_MS = 300000
+    const stallCheck = setInterval(() => {
+      const stallDuration = Date.now() - lastOutputTime
+      if (stallDuration > STALL_TIMEOUT_MS) {
+        clearInterval(stallCheck)
+        child.kill()
+        const stallMin = Math.round(stallDuration / 60000)
+        reject(new Error(`[${agentName}] stalled — no output for ${stallMin} minutes (generated ${(charCount / 1024).toFixed(0)}KB before stall)`))
+      }
+    }, 30000)
+
     child.on('close', (code) => {
       clearTimeout(timeout)
+      clearInterval(stallCheck)
       // Process any remaining data in the line buffer
       if (lineBuffer.trim()) {
         try {
@@ -160,6 +175,7 @@ export async function callClaudeCLI(agentName, systemPrompt, promptText, options
 
     child.on('error', (err) => {
       clearTimeout(timeout)
+      clearInterval(stallCheck)
       reject(err)
     })
   })

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,16 @@
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist/client",
   "framework": null,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/archive/:date/:file", "destination": "/archive/:date/:file" },
     { "source": "/archive/:date/work/:file", "destination": "/archive/:date/work/:file" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,16 +138,10 @@ function pipelineApiPlugin(): Plugin {
           try {
             const { moodOverride, notes } = JSON.parse(body)
             const signalsPath = resolve('signals/today.yml')
-            let content = readFileSync(signalsPath, 'utf8')
-            content = content.replace(/^mood_override:.*$/m, `mood_override: ${moodOverride ? `"${moodOverride}"` : 'null'}`)
-            if (notes) {
-              if (content.includes('notes:')) {
-                content = content.replace(/^notes:.*$/m, `notes: "${notes}"`)
-              } else {
-                content += `\nnotes: "${notes}"\n`
-              }
-            }
-            writeFileSync(signalsPath, content, 'utf8')
+            const signals = yaml.load(readFileSync(signalsPath, 'utf8')) as Record<string, unknown>
+            signals.mood_override = moodOverride ? String(moodOverride) : null
+            if (notes) signals.notes = String(notes)
+            writeFileSync(signalsPath, yaml.dump(signals, { lineWidth: 120 }), 'utf8')
             res.writeHead(200, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify({ ok: true }))
           } catch (err) {


### PR DESCRIPTION
## Summary

### Pipeline reliability (5 fixes)
- **Archetype extraction** — was matching forbidden archetype names from constraint text instead of the actual choice. Now parses the structured `**Archetype:**` declaration line first, falls back to last-match scanning
- **Stall detection** — adds 5-minute no-output kill to Claude CLI calls. Previously hung processes waited the full 30-minute timeout before retry could kick in
- **Spec-critic context** — passes archetype constraints to the critic so it doesn't reject valid substitutions (was causing 10+ min revision loops)
- **identifyFailingAgent** — was returning `token-designer` when both agents failed, so unified-designer was never retried
- **Retry archive** — was recording the original file list after a retry, not the retry results

### Security (3 fixes)
- Fix YAML injection in vite.config.ts `/api/dev-overrides` — use `yaml.dump()` instead of raw string replacement
- Add runtime validation to `saveOverrides` inputValidator (was a no-op TypeScript cast)
- Add security headers to `vercel.json` (nosniff, DENY, strict-origin-when-cross-origin)

### Cleanup (2 fixes)
- Remove dead `gitCommit` function with overly broad `git add -A`
- Guard empty Alpha Vantage response in market signal provider

## Test plan
- [x] 130 unit tests pass
- [x] 17/17 site-health e2e tests pass
- [x] `pnpm build` passes
- [x] Archetype extraction tested against 4 known-bad cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)