### PR TITLE
fix: stall detection should only track actual content output

### DIFF
--- a/scripts/utils/claude-cli.js
+++ b/scripts/utils/claude-cli.js
@@ -91,7 +91,6 @@ export async function callClaudeCLI(agentName, systemPrompt, promptText, options
     promptStream.pipe(child.stdin)
 
     child.stdout.on('data', (chunk) => {
-      lastOutputTime = Date.now()
       lineBuffer += chunk.toString()
       const lines = lineBuffer.split('\n')
       // Keep the last incomplete line in the buffer
@@ -103,12 +102,15 @@ export async function callClaudeCLI(agentName, systemPrompt, promptText, options
           const event = JSON.parse(line)
 
           if (event.type === 'assistant' && event.message?.content) {
-            // Content block with text -- accumulate and show progress
+            // Content block with text -- accumulate and show progress.
+            // Only update lastOutputTime when actual text content arrives
+            // (not on init/heartbeat events) so stall detection is accurate.
             for (const block of event.message.content) {
               if (block.type === 'text' && block.text) {
                 fullText += block.text
                 const newChars = block.text.length
                 charCount += newChars
+                lastOutputTime = Date.now()
                 // Log progress every ~2000 chars so the SSE stream shows activity
                 if (charCount > 0 && charCount % 2000 < newChars) {
                   console.log(`  [${agentName}] ... generating (${(charCount / 1024).toFixed(0)}KB)`)
@@ -118,6 +120,7 @@ export async function callClaudeCLI(agentName, systemPrompt, promptText, options
           } else if (event.type === 'result') {
             // Final result -- this is the complete response
             finalResult = event.result || ''
+            lastOutputTime = Date.now()
           }
         } catch {
           // Not valid JSON -- skip


### PR DESCRIPTION
## Summary

Today's pipeline (2026-04-09) failed with the unified-designer hitting the full 30-minute timeout with **0KB generated**. The 15-minute stall detection from #38 should have killed it at 15 minutes, but didn't fire.

**Root cause:** The stall detection updated \`lastOutputTime\` on every raw stdout chunk. The Claude CLI sends periodic init messages, heartbeats, and empty content events that reset the stall timer without producing actual text content. Stdout was "active" from the stall detector's perspective, but no content was being generated.

**Fix:** Only update \`lastOutputTime\` when we receive actual text content from an assistant message or a final result event. Now the stall detection will correctly fire when the Claude CLI is alive but not generating content.

## Test plan
- [x] 130 unit tests pass
- [x] \`pnpm build\` passes

## Remaining concern

This fix makes the stall detection work correctly, but it still doesn't explain **why** the unified-designer produced zero content for 30 minutes in today's run (and 22+ min in prior runs). The underlying issue — whether it's API capacity, prompt size, or a Claude CLI regression — still needs investigation. For now, at least the pipeline will fail fast (15 min) instead of slow (30 min) when this happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)