### PR TITLE
fix: pin Claude CLI to 2.1.92 — fixes daily redesign pipeline

### DIFF
--- a/.github/workflows/daily-redesign.yml
+++ b/.github/workflows/daily-redesign.yml
@@ -33,7 +33,10 @@ jobs:
         run: pnpm install
 
       - name: Install Claude CLI
-        run: npm install -g @anthropic-ai/claude-code
+        # Pinned to 2.1.92 — versions 2.1.94+ caused the unified-designer
+        # agent to produce 0KB output for large (56KB) prompts in CI.
+        # See PR #40 for investigation. Bump after verifying in a test run.
+        run: npm install -g @anthropic-ai/claude-code@2.1.92
 
       - name: Collect signals
         env:


### PR DESCRIPTION
## Root cause

The daily redesign pipeline has failed every day since 2026-04-08. Version timeline matches the failure pattern exactly:

| Date | CLI version | Result |
|------|-------------|--------|
| Apr 2-7 | 2.1.92 | ✅ all succeeded (7 days in a row) |
| **Apr 7 21:04 UTC** | **2.1.94 released** | |
| Apr 8 10:23 UTC | 2.1.94 | ❌ failed (unified-designer 0KB) |
| Apr 8 21:27 UTC | 2.1.97 released | |
| Apr 9 10:26 UTC | 2.1.97 | ❌ failed (unified-designer 0KB, full 30-min timeout) |

The workflow runs \`npm install -g @anthropic-ai/claude-code\` (no version pin), so it picks up whatever version is current. The pipeline worked with 2.1.92 for 7 consecutive days, then broke the day 2.1.94 was released, and has failed every day since.

**What breaks:** The \`unified-designer\` agent (56KB prompt, generates 5 files) produces zero output for 30 minutes straight. Other agents with smaller prompts (design-director 14KB, token-designer 20KB) continue to work fine — this is specific to large prompts in CLI ≥ 2.1.94.

## Fix

Pin the Claude CLI to \`2.1.92\` — the last known-good version. Leaves a clear comment that the pin should be re-evaluated after testing a newer version in a workflow_dispatch run.

## Testing plan after merge
1. Trigger a \`workflow_dispatch\` run to confirm the pipeline works again
2. Once verified, optionally test newer CLI versions in isolated runs before bumping the pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)