### PR TITLE
fix: prevent Vercel CDN from caching stale daily designs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,24 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
       ]
+    },
+    {
+      "source": "/_shell.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/assets/:path*",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Problem

Today's daily redesign ran successfully and pushed to main, but visitors still see yesterday's design. Vercel's CDN was caching `_shell.html` for 28+ hours (`age: 101227`, `last-modified: Thu, 09 Apr`). Since the entire site is an SPA that loads from `_shell.html`, a stale cache means the new design never reaches users.

## Fix

Add `Cache-Control` headers in `vercel.json`:

| Path | Policy | Why |
|------|--------|-----|
| `/_shell.html`, `/index.html` | `no-cache, no-store, must-revalidate` | Changes every day with the redesign. Must always fetch from origin. |
| `/assets/*` | `public, max-age=31536000, immutable` | JS/CSS bundles have content hashes in filenames. Safe to cache forever — new deploys create new filenames. |

This ensures every visitor gets today's design while still getting fast CDN-cached asset loads.

## Test plan
- [x] 207 unit tests pass
- [x] 17/17 site-health e2e tests pass
- [x] `pnpm build` passes

After merge, the next Vercel deploy will pick up the new headers. Existing CDN cache entries will expire naturally, or you can trigger a redeploy from the Vercel dashboard to flush immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)