### PR TITLE
fix: add github.com to URL allowlist and harden designer prompts

### DIFF
--- a/scripts/prompts/token-designer.md
+++ b/scripts/prompts/token-designer.md
@@ -110,6 +110,10 @@ semanticTokens: {
 }
 ```
 
+## External URL Restriction
+
+Your code must NOT contain URLs to any external domain except: `fonts.googleapis.com`, `fonts.gstatic.com`. The only URLs you should write are Google Fonts stylesheet links. Any other external URL will fail the build validator.
+
 ## CRITICAL: Avoid These Errors
 
 **NEVER create circular token references.** A semantic token must NOT reference itself. This breaks PandaCSS at runtime:

--- a/scripts/prompts/unified-designer.md
+++ b/scripts/prompts/unified-designer.md
@@ -126,7 +126,11 @@ import type { ReactNode } from 'react'  // CORRECT
 
 **Forbidden imports:** `@remix-run/react`, `react-router-dom`, `next/link`, `@emotion/*`, `styled-components`
 
+**External URL restriction:** Your code must NOT contain URLs to any external domain except: `fonts.googleapis.com`, `fonts.gstatic.com`, `spaceman.llc`, `getfishsticks.com`, `15th.club`, `doug-march.com`, `github.com`. Do not link to signal sources (news sites, weather APIs, etc.) or any other third-party domain. Internal links (e.g., `/about`, `/work/spaceman`, `/archive`) are fine.
+
 **No React hooks** (useState, useEffect) in components — pure display only.
+
+**No runtime network or dynamic code:** Your code must NOT use `fetch()`, `XMLHttpRequest`, `WebSocket`, `EventSource`, `navigator.sendBeacon`, `eval()`, `new Function()`, dynamic `import()`, `dangerouslySetInnerHTML`, `document.write`, `.innerHTML =`, inline `onerror=`/`onclick=` HTML attributes, `atob()`, `btoa()`, or `javascript:` URLs. All content is static — no runtime data fetching or dynamic code execution.
 
 ## Content Data Shapes
 

--- a/scripts/utils/build-validator.js
+++ b/scripts/utils/build-validator.js
@@ -196,6 +196,7 @@ export function validateGenerated() {
     'getfishsticks.com',
     '15th.club',
     'doug-march.com',
+    'github.com',
   ])
 
   // Files to scan: only AI-generated mutable files. Hand-maintained

--- a/tests/scripts/build-validator-scanner.test.js
+++ b/tests/scripts/build-validator-scanner.test.js
@@ -119,6 +119,34 @@ describe('build validator content scanner', () => {
     }
   })
 
+  it('allows URLs to github.com', async () => {
+    writeTestFile(
+      'app/components/__scanner_test.tsx',
+      `const url = 'https://github.com/marchdoe/project'`
+    )
+    const result = await runValidator()
+    if (!result.success) {
+      expect(result.error).not.toContain('__scanner_test.tsx')
+    }
+  })
+
+  it('allows URLs to all allowlisted project domains', async () => {
+    writeTestFile(
+      'app/components/__scanner_test.tsx',
+      `const urls = [
+        'https://spaceman.llc',
+        'https://getfishsticks.com',
+        'https://15th.club',
+        'https://doug-march.com',
+        'https://fonts.gstatic.com/s/inter',
+      ]`
+    )
+    const result = await runValidator()
+    if (!result.success) {
+      expect(result.error).not.toContain('__scanner_test.tsx')
+    }
+  })
+
   it('flags document.write', async () => {
     writeTestFile(
       'app/components/__scanner_test.tsx',


### PR DESCRIPTION
## Summary
- **Root cause:** The 2026-04-12 daily redesign failed because the AI included a `github.com` URL in `index.tsx` — not in the build validator's allowlist, and the prompts never told the AI what URLs are permitted
- Added `github.com` to the URL allowlist (the content type already has a `githubUrl` field)
- Added explicit URL restriction and security pattern rules to the unified-designer and token-designer prompts so the AI knows upfront what's forbidden
- Added tests covering `github.com` and all allowlisted domains

## Test plan
- [x] All 209 unit tests pass (added 2 new)
- [x] Build succeeds locally
- [ ] CI passes on this PR
- [ ] Next daily redesign run succeeds (monitor 2026-04-13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)