### PR TITLE
feat: responsive design measurement + feedback loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,13 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright browsers
+        # Must run before unit tests — the responsive-scorer + viewport-screenshotter
+        # vitest suites launch real Chromium for accurate DOM measurements.
+        run: npx playwright install --with-deps chromium
+
       - name: Run unit tests
         run: npm test
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
 
       - name: Build site
         run: pnpm run build

--- a/app/components/responsive-card.tsx
+++ b/app/components/responsive-card.tsx
@@ -1,0 +1,44 @@
+import type { ResponsiveMetrics } from '../server/archive'
+
+export function ResponsiveCard({ metrics, date }: { metrics: ResponsiveMetrics | null; date: string }) {
+  if (!metrics) return null
+
+  const c = {
+    bg: '#0e1014', border: '#2a2f36', muted: '#8a8f97',
+    text: '#dce0e6', cyan: '#00e5ff', font: 'JetBrains Mono, monospace',
+  }
+  const order = ['mobile', 'tablet', 'laptop', 'desktop'] as const
+  const base = `/archive/${date}/viewports`
+
+  return (
+    <div style={{ border: `1px solid ${c.border}`, padding: 12, marginBottom: 12, fontFamily: c.font, fontSize: 11, color: c.text, background: c.bg }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+        <strong>Responsive Score</strong>
+        <span style={{ color: c.cyan, fontWeight: 700 }}>{metrics.overallScore} / 5</span>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
+        {order.map(name => {
+          const v = metrics.viewports[name]
+          if (!v) return null
+          return (
+            <div key={name} style={{ border: `1px solid ${c.border}`, padding: 6 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: c.muted, marginBottom: 4 }}>
+                <span>{name} {v.width}</span>
+                <span>{v.score}/5</span>
+              </div>
+              <a href={`${base}/${name}.png`} target="_blank" rel="noreferrer">
+                <img src={`${base}/${name}.png`} alt={`${name} viewport screenshot`} style={{ width: '100%', height: 'auto', display: 'block' }} />
+              </a>
+            </div>
+          )
+        })}
+      </div>
+      {metrics.worstFailure && (
+        <div style={{ marginTop: 8, padding: 8, border: `1px solid ${c.border}`, color: c.muted }}>
+          <strong style={{ color: c.text }}>{metrics.worstFailure.viewport}</strong>{' '}
+          — {metrics.worstFailure.check}: {metrics.worstFailure.detail}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/components/responsive-trend.tsx
+++ b/app/components/responsive-trend.tsx
@@ -7,7 +7,7 @@ const COLORS = { border: '#2a2f36', muted: '#8a8f97', text: '#dce0e6', cyan: '#0
 function LineChart({ data, label }: { data: Array<{ x: number; y: number; labelX?: string }>; label: string }) {
   const W = 600, H = 120, pad = 24
   if (data.length === 0) return <div style={{ color: COLORS.muted }}>no data</div>
-  const xs = data.map(d => d.x), ys = data.map(d => d.y)
+  const xs = data.map(d => d.x)
   const xMin = Math.min(...xs), xMax = Math.max(...xs)
   const yMin = 1, yMax = 5
   const sx = (x: number) => pad + ((x - xMin) / Math.max(1, xMax - xMin)) * (W - pad * 2)

--- a/app/components/responsive-trend.tsx
+++ b/app/components/responsive-trend.tsx
@@ -1,0 +1,113 @@
+import type { ResponsiveMetrics } from '../server/archive'
+
+type HistoryItem = ResponsiveMetrics
+
+const COLORS = { border: '#2a2f36', muted: '#8a8f97', text: '#dce0e6', cyan: '#00e5ff', fail: '#ff6b6b' }
+
+function LineChart({ data, label }: { data: Array<{ x: number; y: number; labelX?: string }>; label: string }) {
+  const W = 600, H = 120, pad = 24
+  if (data.length === 0) return <div style={{ color: COLORS.muted }}>no data</div>
+  const xs = data.map(d => d.x), ys = data.map(d => d.y)
+  const xMin = Math.min(...xs), xMax = Math.max(...xs)
+  const yMin = 1, yMax = 5
+  const sx = (x: number) => pad + ((x - xMin) / Math.max(1, xMax - xMin)) * (W - pad * 2)
+  const sy = (y: number) => H - pad - ((y - yMin) / (yMax - yMin)) * (H - pad * 2)
+  const poly = data.map(d => `${sx(d.x)},${sy(d.y)}`).join(' ')
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div style={{ fontSize: 11, color: COLORS.muted, marginBottom: 4 }}>{label}</div>
+      <svg width={W} height={H} style={{ border: `1px solid ${COLORS.border}` }}>
+        <polyline points={poly} fill="none" stroke={COLORS.cyan} strokeWidth={1.5} />
+        {data.map((d, i) => (
+          <circle key={i} cx={sx(d.x)} cy={sy(d.y)} r={2.5} fill={COLORS.cyan}>
+            <title>{`${d.labelX || d.x}: ${d.y}/5`}</title>
+          </circle>
+        ))}
+      </svg>
+    </div>
+  )
+}
+
+function BarChart({ rows }: { rows: Array<{ label: string; count: number }> }) {
+  const max = Math.max(1, ...rows.map(r => r.count))
+  return (
+    <div style={{ marginBottom: 16 }}>
+      {rows.map(r => (
+        <div key={r.label} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11, marginBottom: 2 }}>
+          <span style={{ width: 180 }}>{r.label}</span>
+          <div style={{ flex: 1, background: COLORS.border, height: 12, position: 'relative' }}>
+            <div style={{ width: `${(r.count / max) * 100}%`, height: '100%', background: COLORS.fail }} />
+          </div>
+          <span style={{ width: 40, textAlign: 'right', color: COLORS.muted }}>{r.count}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ResponsiveTrend({ history }: { history: HistoryItem[] }) {
+  const asc = [...history].sort((a, b) => a.date.localeCompare(b.date))
+
+  const overallData = asc.map((h, i) => ({ x: i, y: h.overallScore, labelX: h.date }))
+
+  const perVp = ['mobile', 'tablet', 'laptop', 'desktop']
+  const perVpSeries = perVp.map(name => ({
+    name,
+    data: asc.map((h, i) => ({ x: i, y: h.viewports?.[name]?.score ?? 0, labelX: h.date })),
+  }))
+
+  const failCounts: Record<string, number> = {}
+  for (const h of history) {
+    if (h.worstFailure?.check) failCounts[h.worstFailure.check] = (failCounts[h.worstFailure.check] || 0) + 1
+  }
+  const failRows = Object.entries(failCounts)
+    .sort(([, a], [, b]) => b - a)
+    .map(([label, count]) => ({ label, count }))
+
+  const byArchetype: Record<string, { total: number; n: number }> = {}
+  for (const h of history) {
+    const k = h.archetype || 'unknown'
+    if (!byArchetype[k]) byArchetype[k] = { total: 0, n: 0 }
+    byArchetype[k].total += h.overallScore
+    byArchetype[k].n += 1
+  }
+  const archRows = Object.entries(byArchetype)
+    .map(([k, { total, n }]) => ({ archetype: k, avg: (total / n).toFixed(1), n }))
+    .sort((a, b) => parseFloat(a.avg) - parseFloat(b.avg))
+
+  const worstBuilds = [...history]
+    .filter(h => h.overallScore <= 3)
+    .sort((a, b) => a.overallScore - b.overallScore)
+    .slice(0, 10)
+
+  return (
+    <div>
+      <LineChart data={overallData} label={`Overall score (last ${asc.length} builds)`} />
+      {perVpSeries.map(s => (
+        <LineChart key={s.name} data={s.data} label={`${s.name} score`} />
+      ))}
+
+      <div style={{ fontSize: 11, color: COLORS.muted, marginBottom: 4, marginTop: 16 }}>Failure types</div>
+      <BarChart rows={failRows} />
+
+      <div style={{ fontSize: 11, color: COLORS.muted, marginBottom: 4, marginTop: 16 }}>Worst by archetype</div>
+      <table style={{ fontSize: 11, borderCollapse: 'collapse' }}>
+        <thead><tr><th style={{ textAlign: 'left', padding: 4 }}>archetype</th><th style={{ padding: 4 }}>avg</th><th style={{ padding: 4 }}>n</th></tr></thead>
+        <tbody>{archRows.map(r => (
+          <tr key={r.archetype}><td style={{ padding: 4 }}>{r.archetype}</td><td style={{ padding: 4 }}>{r.avg}</td><td style={{ padding: 4 }}>{r.n}</td></tr>
+        ))}</tbody>
+      </table>
+
+      <div style={{ fontSize: 11, color: COLORS.muted, marginBottom: 4, marginTop: 16 }}>Worst recent builds</div>
+      <ul style={{ fontSize: 11, paddingLeft: 16 }}>
+        {worstBuilds.map(b => (
+          <li key={b.buildId}>
+            <a href={`/dev?date=${b.date}&buildId=${b.buildId}`} style={{ color: COLORS.cyan }}>
+              {b.date} · {b.archetype || '—'} · {b.overallScore}/5
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/components/responsive-trend.tsx
+++ b/app/components/responsive-trend.tsx
@@ -102,7 +102,7 @@ export function ResponsiveTrend({ history }: { history: HistoryItem[] }) {
       <ul style={{ fontSize: 11, paddingLeft: 16 }}>
         {worstBuilds.map(b => (
           <li key={b.buildId}>
-            <a href={`/dev?date=${b.date}&buildId=${b.buildId}`} style={{ color: COLORS.cyan }}>
+            <a href={`/archive/${b.date}`} style={{ color: COLORS.cyan }}>
               {b.date} · {b.archetype || '—'} · {b.overallScore}/5
             </a>
           </li>

--- a/app/dev-panel.tsx
+++ b/app/dev-panel.tsx
@@ -1,4 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
+import { ResponsiveCard } from './components/responsive-card'
+import { readResponsiveMetrics } from './server/archive'
+import type { ResponsiveMetrics } from './server/archive'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -2240,6 +2243,16 @@ function SuccessSection({ brief, timestamp, buildId, attemptNum, archive, totalM
   const [ratingError, setRatingError] = useState('')
   const [saveAsReference, setSaveAsReference] = useState(false)
   const [referenceConfirmation, setReferenceConfirmation] = useState('')
+  const [responsiveMetrics, setResponsiveMetrics] = useState<ResponsiveMetrics | null>(null)
+
+  useEffect(() => {
+    if (!ratingDate || !buildId) return
+    let cancelled = false
+    readResponsiveMetrics({ data: { date: ratingDate, buildId } })
+      .then(m => { if (!cancelled) setResponsiveMetrics(m ?? null) })
+      .catch(() => { if (!cancelled) setResponsiveMetrics(null) })
+    return () => { cancelled = true }
+  }, [ratingDate, buildId])
 
   // Each build starts fresh — no pre-population from previous ratings
 
@@ -2456,6 +2469,7 @@ function SuccessSection({ brief, timestamp, buildId, attemptNum, archive, totalM
 
       {/* Rating form */}
       <div style={{ padding: '12px 16px', borderTop: `1px solid rgba(92,190,74,0.1)` }}>
+        <ResponsiveCard metrics={responsiveMetrics} date={ratingDate} />
         <div style={{
           fontSize: '9px',
           fontWeight: 700,

--- a/app/routeTree.gen.ts
+++ b/app/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as ArchiveRouteImport } from './routes/archive'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkSlugRouteImport } from './routes/work.$slug'
+import { Route as DevResponsiveRouteImport } from './routes/dev.responsive'
 import { Route as ArchiveDateRouteImport } from './routes/archive.$date'
 
 const ElementsRoute = ElementsRouteImport.update({
@@ -47,6 +48,11 @@ const WorkSlugRoute = WorkSlugRouteImport.update({
   path: '/work/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DevResponsiveRoute = DevResponsiveRouteImport.update({
+  id: '/responsive',
+  path: '/responsive',
+  getParentRoute: () => DevRoute,
+} as any)
 const ArchiveDateRoute = ArchiveDateRouteImport.update({
   id: '/$date',
   path: '/$date',
@@ -57,18 +63,20 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/archive': typeof ArchiveRouteWithChildren
-  '/dev': typeof DevRoute
+  '/dev': typeof DevRouteWithChildren
   '/elements': typeof ElementsRoute
   '/archive/$date': typeof ArchiveDateRoute
+  '/dev/responsive': typeof DevResponsiveRoute
   '/work/$slug': typeof WorkSlugRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/archive': typeof ArchiveRouteWithChildren
-  '/dev': typeof DevRoute
+  '/dev': typeof DevRouteWithChildren
   '/elements': typeof ElementsRoute
   '/archive/$date': typeof ArchiveDateRoute
+  '/dev/responsive': typeof DevResponsiveRoute
   '/work/$slug': typeof WorkSlugRoute
 }
 export interface FileRoutesById {
@@ -76,9 +84,10 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/archive': typeof ArchiveRouteWithChildren
-  '/dev': typeof DevRoute
+  '/dev': typeof DevRouteWithChildren
   '/elements': typeof ElementsRoute
   '/archive/$date': typeof ArchiveDateRoute
+  '/dev/responsive': typeof DevResponsiveRoute
   '/work/$slug': typeof WorkSlugRoute
 }
 export interface FileRouteTypes {
@@ -90,6 +99,7 @@ export interface FileRouteTypes {
     | '/dev'
     | '/elements'
     | '/archive/$date'
+    | '/dev/responsive'
     | '/work/$slug'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -99,6 +109,7 @@ export interface FileRouteTypes {
     | '/dev'
     | '/elements'
     | '/archive/$date'
+    | '/dev/responsive'
     | '/work/$slug'
   id:
     | '__root__'
@@ -108,6 +119,7 @@ export interface FileRouteTypes {
     | '/dev'
     | '/elements'
     | '/archive/$date'
+    | '/dev/responsive'
     | '/work/$slug'
   fileRoutesById: FileRoutesById
 }
@@ -115,7 +127,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
   ArchiveRoute: typeof ArchiveRouteWithChildren
-  DevRoute: typeof DevRoute
+  DevRoute: typeof DevRouteWithChildren
   ElementsRoute: typeof ElementsRoute
   WorkSlugRoute: typeof WorkSlugRoute
 }
@@ -164,6 +176,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/dev/responsive': {
+      id: '/dev/responsive'
+      path: '/responsive'
+      fullPath: '/dev/responsive'
+      preLoaderRoute: typeof DevResponsiveRouteImport
+      parentRoute: typeof DevRoute
+    }
     '/archive/$date': {
       id: '/archive/$date'
       path: '/$date'
@@ -185,11 +204,21 @@ const ArchiveRouteChildren: ArchiveRouteChildren = {
 const ArchiveRouteWithChildren =
   ArchiveRoute._addFileChildren(ArchiveRouteChildren)
 
+interface DevRouteChildren {
+  DevResponsiveRoute: typeof DevResponsiveRoute
+}
+
+const DevRouteChildren: DevRouteChildren = {
+  DevResponsiveRoute: DevResponsiveRoute,
+}
+
+const DevRouteWithChildren = DevRoute._addFileChildren(DevRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
   ArchiveRoute: ArchiveRouteWithChildren,
-  DevRoute: DevRoute,
+  DevRoute: DevRouteWithChildren,
   ElementsRoute: ElementsRoute,
   WorkSlugRoute: WorkSlugRoute,
 }

--- a/app/routes/dev.responsive.tsx
+++ b/app/routes/dev.responsive.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { ResponsiveTrend } from '../components/responsive-trend'
+import { readResponsiveHistory } from '../server/archive'
+
+export const Route = createFileRoute('/dev/responsive')({
+  beforeLoad: () => {
+    if (import.meta.env.PROD) {
+      throw notFound()
+    }
+  },
+  loader: async () => ({
+    history: await readResponsiveHistory({ data: { limit: 30 } }),
+  }),
+  component: ResponsivePage,
+})
+
+function ResponsivePage() {
+  const { history } = Route.useLoaderData()
+  return (
+    <div style={{ padding: 16, fontFamily: 'JetBrains Mono, monospace', fontSize: 12, background: '#0e1014', color: '#dce0e6', minHeight: '100vh' }}>
+      <h1 style={{ fontSize: 14, marginBottom: 16 }}>Responsive — last 30 builds</h1>
+      <ResponsiveTrend history={history} />
+    </div>
+  )
+}

--- a/app/routes/dev.tsx
+++ b/app/routes/dev.tsx
@@ -1,5 +1,5 @@
 // app/routes/dev.tsx
-import { createFileRoute, notFound } from '@tanstack/react-router'
+import { createFileRoute, notFound, Outlet, useMatch } from '@tanstack/react-router'
 import { useState, useRef, useEffect } from 'react'
 import { readSignals, saveOverrides } from '../server/signals'
 import { readArchive, readArchiveDetail, type ArchiveEntry } from '../server/archive'
@@ -142,6 +142,9 @@ const s = {
 function DevPanel() {
   const { signals: initialSignals, archive } = Route.useLoaderData()
   const signals = initialSignals as Signals
+  // If a child route (e.g. /dev/responsive) is active, yield to it
+  const childMatch = useMatch({ from: '/dev/responsive', shouldThrow: false })
+  if (childMatch) return <Outlet />
 
   const [activePane, setActivePane] = useState<PaneName>('pipeline')
   const [traceSteps, setTraceSteps] = useState<any[]>([])

--- a/app/routes/dev.tsx
+++ b/app/routes/dev.tsx
@@ -140,11 +140,15 @@ const s = {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 function DevPanel() {
-  const { signals: initialSignals, archive } = Route.useLoaderData()
-  const signals = initialSignals as Signals
-  // If a child route (e.g. /dev/responsive) is active, yield to it
+  const loaderData = Route.useLoaderData()
   const childMatch = useMatch({ from: '/dev/responsive', shouldThrow: false })
   if (childMatch) return <Outlet />
+  return <DevPanelBody loaderData={loaderData} />
+}
+
+function DevPanelBody({ loaderData }: { loaderData: ReturnType<typeof Route.useLoaderData> }) {
+  const { signals: initialSignals, archive } = loaderData
+  const signals = initialSignals as Signals
 
   const [activePane, setActivePane] = useState<PaneName>('pipeline')
   const [traceSteps, setTraceSteps] = useState<any[]>([])

--- a/app/server/archive-impl.ts
+++ b/app/server/archive-impl.ts
@@ -114,3 +114,38 @@ export function _readResponsiveMetrics(
     return null
   }
 }
+
+/**
+ * Read recent responsive-metrics.json files across archive dirs.
+ * Returned newest-first (by date desc, then buildId desc), limited to `limit`.
+ */
+export function _readResponsiveHistory(
+  limit = 30,
+  archivePath = ARCHIVE_PATH
+): ResponsiveMetrics[] {
+  if (!existsSync(archivePath)) return []
+
+  const dates = readdirSync(archivePath)
+    .filter(d => /^\d{4}-\d{2}-\d{2}$/.test(d))
+    .sort()
+    .reverse()
+
+  const out: ResponsiveMetrics[] = []
+  for (const date of dates) {
+    const dateDir = join(archivePath, date)
+    let builds: string[]
+    try {
+      builds = readdirSync(dateDir).filter(b => b.startsWith('build-'))
+    } catch { continue }
+    builds.sort().reverse()
+    for (const b of builds) {
+      const p = join(dateDir, b, 'responsive-metrics.json')
+      if (!existsSync(p)) continue
+      try {
+        out.push(JSON.parse(readFileSync(p, 'utf8')) as ResponsiveMetrics)
+      } catch { /* skip invalid */ }
+      if (out.length >= limit) return out
+    }
+  }
+  return out
+}

--- a/app/server/archive-impl.ts
+++ b/app/server/archive-impl.ts
@@ -83,6 +83,15 @@ export function _readArchiveHandler(archivePath = ARCHIVE_PATH): ArchiveEntry[] 
     .sort((a, b) => b.date.localeCompare(a.date))
 }
 
+export interface ResponsiveChecks {
+  horizontalScroll?: boolean
+  clippedElements?: Array<{ tag: string; text: string; right: number }>
+  headerOverlap?: Array<{ a: string; b: string }>
+  bodyTextSize?: { min: number | null; passing: boolean }
+  tapTargetFailures?: Array<{ tag: string; text: string; w: number; h: number }>
+  lineLengthFailures?: Array<{ chars: number; lines: number; avgPerLine: number; excerpt: string }>
+}
+
 export interface ResponsiveMetrics {
   buildId: string
   date: string
@@ -93,7 +102,7 @@ export interface ResponsiveMetrics {
     width: number
     height: number
     score: number
-    checks: Record<string, unknown>
+    checks: ResponsiveChecks
   }>
   usedInPromptFor?: string[]
 }

--- a/app/server/archive-impl.ts
+++ b/app/server/archive-impl.ts
@@ -82,3 +82,35 @@ export function _readArchiveHandler(archivePath = ARCHIVE_PATH): ArchiveEntry[] 
     .filter((e): e is ArchiveEntry => e !== null)
     .sort((a, b) => b.date.localeCompare(a.date))
 }
+
+export interface ResponsiveMetrics {
+  buildId: string
+  date: string
+  archetype: string | null
+  overallScore: number
+  worstFailure: { viewport: string; check: string; detail: string } | null
+  viewports: Record<string, {
+    width: number
+    height: number
+    score: number
+    checks: Record<string, unknown>
+  }>
+  usedInPromptFor?: string[]
+}
+
+/**
+ * Read responsive-metrics.json for a given build. Returns null if missing or unparseable.
+ */
+export function _readResponsiveMetrics(
+  date: string,
+  buildId: string,
+  archivePath = ARCHIVE_PATH
+): ResponsiveMetrics | null {
+  const p = join(archivePath, date, `build-${buildId}`, 'responsive-metrics.json')
+  if (!existsSync(p)) return null
+  try {
+    return JSON.parse(readFileSync(p, 'utf8')) as ResponsiveMetrics
+  } catch {
+    return null
+  }
+}

--- a/app/server/archive.ts
+++ b/app/server/archive.ts
@@ -1,7 +1,7 @@
 // app/server/archive.ts
 'use server'
 import { createServerFn } from '@tanstack/react-start'
-import { _readArchiveHandler, _readResponsiveMetrics } from './archive-impl'
+import { _readArchiveHandler, _readResponsiveMetrics, _readResponsiveHistory } from './archive-impl'
 import { _readArchiveDetail } from './archive-detail-impl'
 export type { ArchiveEntry } from './archive-impl'
 export type { ArchiveDetail } from './archive-detail-impl'
@@ -31,4 +31,15 @@ export const readResponsiveMetrics = createServerFn({ method: 'GET' })
   })
   .handler(async ({ data }) => {
     return _readResponsiveMetrics(data.date, data.buildId)
+  })
+
+export const readResponsiveHistory = createServerFn({ method: 'GET' })
+  .inputValidator((d: unknown) => {
+    const obj = d as { limit?: unknown }
+    const limit = typeof obj?.limit === 'number' ? obj.limit : 30
+    if (limit < 1 || limit > 200) throw new Error('limit must be 1..200')
+    return { limit }
+  })
+  .handler(async ({ data }) => {
+    return _readResponsiveHistory(data.limit)
   })

--- a/app/server/archive.ts
+++ b/app/server/archive.ts
@@ -1,10 +1,11 @@
 // app/server/archive.ts
 'use server'
 import { createServerFn } from '@tanstack/react-start'
-import { _readArchiveHandler } from './archive-impl'
+import { _readArchiveHandler, _readResponsiveMetrics } from './archive-impl'
 import { _readArchiveDetail } from './archive-detail-impl'
 export type { ArchiveEntry } from './archive-impl'
 export type { ArchiveDetail } from './archive-detail-impl'
+export type { ResponsiveMetrics } from './archive-impl'
 
 export const readArchive = createServerFn({ method: 'GET' })
   .handler(() => _readArchiveHandler())
@@ -17,4 +18,17 @@ export const readArchiveDetail = createServerFn({ method: 'GET' })
   })
   .handler(async ({ data: date }) => {
     return _readArchiveDetail(date)
+  })
+
+export const readResponsiveMetrics = createServerFn({ method: 'GET' })
+  .inputValidator((d: unknown) => {
+    const obj = d as { date?: unknown; buildId?: unknown }
+    const date = String(obj?.date ?? '')
+    const buildId = String(obj?.buildId ?? '')
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) throw new Error('Invalid date format')
+    if (!/^\d+$/.test(buildId)) throw new Error('Invalid buildId format')
+    return { date, buildId }
+  })
+  .handler(async ({ data }) => {
+    return _readResponsiveMetrics(data.date, data.buildId)
   })

--- a/docs/superpowers/plans/2026-04-17-responsive-design.md
+++ b/docs/superpowers/plans/2026-04-17-responsive-design.md
@@ -1,0 +1,2132 @@
+# Responsive Design System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure every daily build against four viewports (360 / 768 / 1024 / 1440), surface the metrics in /dev, and feed yesterday's worst failure into today's prompt so the system improves over time.
+
+**Architecture:** Four new modules communicate through a JSON metrics contract. `viewport-screenshotter` captures PNGs. `responsive-scorer` inspects the DOM via Playwright and writes metrics. `prompt-feedback-selector` picks a cautionary example from recent history. `/dev` displays screenshots + metrics + trend dashboard. Each module has one job and is independently testable.
+
+**Tech Stack:** Node.js ESM, Playwright (already installed via `@playwright/test`), TanStack Start / React, Panda CSS, vitest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-17-responsive-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `scripts/utils/viewport-screenshotter.js` — screenshot N viewports
+- `scripts/utils/responsive-scorer.js` — score a URL via Playwright
+- `scripts/utils/prompt-feedback-selector.js` — pick a failure to inject
+- `app/routes/dev.responsive.tsx` — trend dashboard route
+- `app/components/responsive-card.tsx` — rating panel card
+- `tests/utils/responsive-scorer.test.js` — scorer unit tests
+- `tests/utils/prompt-feedback-selector.test.js` — selector unit tests
+- `tests/scripts/viewport-screenshotter.test.js` — screenshotter integration test
+- `tests/fixtures/responsive/*.html` — scoring fixtures (one per failure mode)
+- `tests/e2e/dev-responsive-panel.spec.ts` — rating card e2e
+- `tests/e2e/dev-responsive-trend.spec.ts` — trend dashboard e2e
+
+**Modified files:**
+- `scripts/prompts/unified-designer.md` — add responsive section
+- `scripts/prompts/seeds/*.md` — per-archetype mobile strategy (8 files)
+- `scripts/utils/archiver.js` — copy 4 viewport PNGs to public/archive/
+- `scripts/utils/prompt-builder.js` — inject lesson from recent failures
+- `scripts/daily-redesign.js` — orchestrate screenshot + score + write
+- `app/dev-panel.tsx` — render responsive card above rating inputs
+- `app/server/archive-impl.ts` — add `readResponsiveHistory()`
+
+---
+
+# Phase 1: Measurement
+
+Build `responsive-scorer.js` check-by-check (TDD), then `viewport-screenshotter.js`, then wire into the pipeline.
+
+**Note on test infrastructure:** The scorer checks rely on real computed styles and bounding rects, which jsdom cannot faithfully produce. All scorer tests launch a real Chromium instance via `@playwright/test`, with `testTimeout` bumped to 30_000ms in the test file. One shared browser across tests (`beforeAll`/`afterAll`), new page per test.
+
+## Task 1: Create test fixture directory and known-good fixture
+
+**Files:**
+- Create: `tests/fixtures/responsive/clean.html`
+
+- [ ] **Step 1: Create directory and fixture**
+
+```bash
+mkdir -p tests/fixtures/responsive
+```
+
+Write `tests/fixtures/responsive/clean.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: sans-serif; font-size: 16px; line-height: 1.5; }
+    header { display: flex; gap: 16px; padding: 16px; }
+    header > * { flex: 0 0 auto; }
+    a, button { display: inline-block; min-width: 44px; min-height: 44px; padding: 12px; }
+    main { padding: 16px; max-width: 65ch; margin: 0 auto; }
+    h1 { font-size: clamp(2rem, 6vw, 4rem); margin: 0 0 16px; }
+    p { margin: 0 0 16px; }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/">Logo</a>
+    <nav><a href="/about">About</a></nav>
+  </header>
+  <main>
+    <h1>Clean Page</h1>
+    <p>This page should pass every responsive check at every viewport.</p>
+  </main>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/fixtures/responsive/clean.html
+git commit -m "test(responsive): clean fixture for scorer baseline"
+```
+
+---
+
+## Task 2: horizontalScroll check (TDD)
+
+**Files:**
+- Create: `tests/fixtures/responsive/overflow-horizontal.html`
+- Create: `tests/utils/responsive-scorer.test.js`
+- Create: `scripts/utils/responsive-scorer.js`
+
+- [ ] **Step 1: Write failure fixture**
+
+Write `tests/fixtures/responsive/overflow-horizontal.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { margin: 0; padding: 0; }
+    body { font-family: sans-serif; }
+    h1 { font-size: 180px; white-space: nowrap; margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>DOUG MARCH</h1>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Write failing test**
+
+Write `tests/utils/responsive-scorer.test.js`:
+
+```js
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { chromium } from '@playwright/test'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { scoreResponsive } from '../../scripts/utils/responsive-scorer.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.join(__dirname, '../fixtures/responsive')
+const fixtureUrl = (name) => `file://${path.join(FIXTURES, name)}`
+
+describe('responsive-scorer', () => {
+  let browser
+  beforeAll(async () => {
+    browser = await chromium.launch({ headless: true })
+  }, 30_000)
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  describe('horizontalScroll check', () => {
+    it('flags horizontal overflow at 360px', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('overflow-horizontal.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.horizontalScroll).toBe(true)
+    }, 30_000)
+
+    it('does not flag clean pages', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.horizontalScroll).toBe(false)
+    }, 30_000)
+  })
+})
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: FAIL with `Cannot find module '../../scripts/utils/responsive-scorer.js'`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Write `scripts/utils/responsive-scorer.js`:
+
+```js
+import { chromium } from '@playwright/test'
+
+const CHECKS = {
+  horizontalScroll: () =>
+    document.documentElement.scrollWidth > window.innerWidth,
+}
+
+/**
+ * Score a URL across viewports.
+ * Each check runs in the page context after setting viewport.
+ *
+ * @param {string} url
+ * @param {Array<{name, width, height}>} viewports
+ * @param {object} [opts]
+ * @param {import('@playwright/test').Browser} [opts.browser] - optional
+ *   externally-managed browser (tests reuse one; production launches its own)
+ * @returns {Promise<object>} metrics
+ */
+export async function scoreResponsive(url, viewports, opts = {}) {
+  const ownBrowser = !opts.browser
+  const browser = opts.browser || (await chromium.launch({ headless: true }))
+
+  try {
+    const page = await browser.newPage()
+    const viewportResults = {}
+
+    for (const vp of viewports) {
+      await page.setViewportSize({ width: vp.width, height: vp.height })
+      await page.goto(url, { waitUntil: 'networkidle' })
+      await page.waitForTimeout(300)
+
+      const checks = {}
+      for (const [name, fn] of Object.entries(CHECKS)) {
+        checks[name] = await page.evaluate(fn)
+      }
+
+      viewportResults[vp.name] = {
+        width: vp.width,
+        height: vp.height,
+        checks,
+      }
+    }
+
+    await page.close()
+    return { viewports: viewportResults }
+  } finally {
+    if (ownBrowser) await browser.close()
+  }
+}
+```
+
+- [ ] **Step 5: Run test, verify passes**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/responsive/overflow-horizontal.html \
+        tests/utils/responsive-scorer.test.js \
+        scripts/utils/responsive-scorer.js
+git commit -m "feat(responsive): horizontalScroll check + TDD harness"
+```
+
+---
+
+## Task 3: clippedElements check
+
+**Files:**
+- Create: `tests/fixtures/responsive/clipped-hero.html`
+- Modify: `tests/utils/responsive-scorer.test.js`
+- Modify: `scripts/utils/responsive-scorer.js`
+
+- [ ] **Step 1: Write failure fixture**
+
+Write `tests/fixtures/responsive/clipped-hero.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { margin: 0; padding: 0; overflow: hidden; }
+    body { font-family: sans-serif; }
+    .hero { position: absolute; left: 50px; width: 800px; background: red; padding: 20px; color: white; }
+  </style>
+</head>
+<body>
+  <div class="hero">This hero is 800px wide starting at 50px — clipped beyond 360px.</div>
+</body>
+</html>
+```
+
+Note: `overflow: hidden` on body suppresses horizontal scroll but element is still clipped — exactly the bug we need to catch.
+
+- [ ] **Step 2: Add failing test**
+
+Append to `tests/utils/responsive-scorer.test.js` inside the `describe('responsive-scorer')` block:
+
+```js
+  describe('clippedElements check', () => {
+    it('flags elements extending past the viewport', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clipped-hero.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.clippedElements.length).toBeGreaterThan(0)
+      expect(metrics.viewports.mobile.checks.clippedElements[0].tag).toBe('DIV')
+    }, 30_000)
+
+    it('does not flag clean pages', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.clippedElements).toEqual([])
+    }, 30_000)
+  })
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: FAIL — `clippedElements` is `undefined`.
+
+- [ ] **Step 4: Add check to implementation**
+
+In `scripts/utils/responsive-scorer.js`, extend the `CHECKS` object:
+
+```js
+const CHECKS = {
+  horizontalScroll: () =>
+    document.documentElement.scrollWidth > window.innerWidth,
+
+  clippedElements: () => {
+    const vw = window.innerWidth
+    const out = []
+    for (const el of document.querySelectorAll('body *')) {
+      const r = el.getBoundingClientRect()
+      if (r.width === 0 || r.height === 0) continue
+      if (r.right > vw + 1) {
+        out.push({
+          tag: el.tagName,
+          text: (el.textContent || '').trim().slice(0, 50),
+          right: Math.round(r.right),
+        })
+      }
+    }
+    return out
+  },
+}
+```
+
+- [ ] **Step 5: Run test, verify passes**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/responsive/clipped-hero.html \
+        tests/utils/responsive-scorer.test.js \
+        scripts/utils/responsive-scorer.js
+git commit -m "feat(responsive): clippedElements check"
+```
+
+---
+
+## Task 4: headerOverlap check
+
+**Files:**
+- Create: `tests/fixtures/responsive/header-overlap.html`
+- Modify: `tests/utils/responsive-scorer.test.js`
+- Modify: `scripts/utils/responsive-scorer.js`
+
+- [ ] **Step 1: Write failure fixture**
+
+Write `tests/fixtures/responsive/header-overlap.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { margin: 0; padding: 0; }
+    header { position: relative; }
+    header > * {
+      position: absolute; top: 0;
+      padding: 12px; background: rgba(255,0,0,0.3);
+    }
+    .logo { left: 0; width: 200px; }
+    .nav   { left: 100px; width: 200px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">Logo</div>
+    <div class="nav">Nav</div>
+  </header>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Add failing test**
+
+Append:
+
+```js
+  describe('headerOverlap check', () => {
+    it('flags overlapping header children', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('header-overlap.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.headerOverlap.length).toBeGreaterThan(0)
+    }, 30_000)
+
+    it('does not flag non-overlapping header', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.headerOverlap).toEqual([])
+    }, 30_000)
+  })
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: FAIL — `headerOverlap` is `undefined`.
+
+- [ ] **Step 4: Add check**
+
+Extend `CHECKS`:
+
+```js
+  headerOverlap: () => {
+    const header = document.querySelector('header') || document.querySelector('nav')
+    if (!header) return []
+    const kids = [...header.children].map(el => ({ el, r: el.getBoundingClientRect() }))
+    const overlaps = []
+    for (let i = 0; i < kids.length; i++) {
+      for (let j = i + 1; j < kids.length; j++) {
+        const a = kids[i].r, b = kids[j].r
+        const xOverlap = !(a.right <= b.left || b.right <= a.left)
+        const yOverlap = !(a.bottom <= b.top || b.bottom <= a.top)
+        if (xOverlap && yOverlap) {
+          overlaps.push({
+            a: kids[i].el.tagName + (kids[i].el.className ? '.' + kids[i].el.className : ''),
+            b: kids[j].el.tagName + (kids[j].el.className ? '.' + kids[j].el.className : ''),
+          })
+        }
+      }
+    }
+    return overlaps
+  },
+```
+
+- [ ] **Step 5: Run test, verify passes**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/responsive/header-overlap.html \
+        tests/utils/responsive-scorer.test.js \
+        scripts/utils/responsive-scorer.js
+git commit -m "feat(responsive): headerOverlap check"
+```
+
+---
+
+## Task 5: bodyTextSize check
+
+**Files:**
+- Create: `tests/fixtures/responsive/tiny-body.html`
+- Modify: `tests/utils/responsive-scorer.test.js`
+- Modify: `scripts/utils/responsive-scorer.js`
+
+- [ ] **Step 1: Write failure fixture**
+
+Write `tests/fixtures/responsive/tiny-body.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style>body { font-family: sans-serif; font-size: 12px; margin: 16px; }</style></head>
+<body><main><p>This body text is 12 pixels — below the 16px floor.</p></main></body>
+</html>
+```
+
+- [ ] **Step 2: Add failing test**
+
+Append:
+
+```js
+  describe('bodyTextSize check', () => {
+    it('flags body text below 16px', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('tiny-body.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.bodyTextSize.min).toBeLessThan(16)
+      expect(metrics.viewports.mobile.checks.bodyTextSize.passing).toBe(false)
+    }, 30_000)
+
+    it('passes on 16px body', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.bodyTextSize.passing).toBe(true)
+    }, 30_000)
+  })
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: FAIL.
+
+- [ ] **Step 4: Add check**
+
+Extend `CHECKS`:
+
+```js
+  bodyTextSize: () => {
+    const root = document.querySelector('main') || document.body
+    let min = Infinity
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    let n
+    while ((n = walker.nextNode())) {
+      const text = (n.textContent || '').trim()
+      if (text.length < 8) continue
+      const parent = n.parentElement
+      if (!parent) continue
+      const fs = parseFloat(getComputedStyle(parent).fontSize)
+      if (fs && fs < min) min = fs
+    }
+    if (min === Infinity) return { min: null, passing: true }
+    return { min: Math.round(min * 10) / 10, passing: min >= 16 }
+  },
+```
+
+- [ ] **Step 5: Run test, verify passes**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: PASS (8 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/responsive/tiny-body.html \
+        tests/utils/responsive-scorer.test.js \
+        scripts/utils/responsive-scorer.js
+git commit -m "feat(responsive): bodyTextSize check"
+```
+
+---
+
+## Task 6: tapTargetFailures check
+
+**Files:**
+- Create: `tests/fixtures/responsive/small-tap-targets.html`
+- Modify: `tests/utils/responsive-scorer.test.js`
+- Modify: `scripts/utils/responsive-scorer.js`
+
+- [ ] **Step 1: Write failure fixture**
+
+Write `tests/fixtures/responsive/small-tap-targets.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style>body{font-family:sans-serif;margin:16px} a,button{padding:2px;font-size:10px;display:inline-block}</style></head>
+<body>
+  <nav><a href="/about">About</a> <button>Menu</button></nav>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Add failing test**
+
+```js
+  describe('tapTargetFailures check', () => {
+    it('flags links/buttons under 44x44 at mobile', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('small-tap-targets.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.tapTargetFailures.length).toBeGreaterThanOrEqual(2)
+    }, 30_000)
+
+    it('does not flag at desktop width', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('small-tap-targets.html'),
+        [{ name: 'desktop', width: 1440, height: 900 }],
+        { browser }
+      )
+      expect(metrics.viewports.desktop.checks.tapTargetFailures).toEqual([])
+    }, 30_000)
+
+    it('passes on clean page', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.tapTargetFailures).toEqual([])
+    }, 30_000)
+  })
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: FAIL.
+
+- [ ] **Step 4: Add check**
+
+Extend `CHECKS`. Note — tap-target rule only applies at mobile/tablet widths (≤ 768). Scorer must know the current viewport; pass it in:
+
+In `scripts/utils/responsive-scorer.js`, modify the scoring loop:
+
+```js
+const CHECKS = {
+  // ... existing checks stay pure (no args) ...
+
+  tapTargetFailures: (viewportWidth) => {
+    if (viewportWidth > 768) return []
+    const selectors = 'a[href], button, [role="button"], input[type="button"], input[type="submit"]'
+    const out = []
+    for (const el of document.querySelectorAll(selectors)) {
+      const r = el.getBoundingClientRect()
+      if (r.width === 0 || r.height === 0) continue
+      if (r.width < 44 || r.height < 44) {
+        out.push({
+          tag: el.tagName,
+          text: (el.textContent || '').trim().slice(0, 30),
+          w: Math.round(r.width),
+          h: Math.round(r.height),
+        })
+      }
+    }
+    return out
+  },
+}
+```
+
+Modify the evaluation loop to pass viewport width:
+
+```js
+      const checks = {}
+      for (const [name, fn] of Object.entries(CHECKS)) {
+        // Pass viewport width as second arg — most checks ignore it.
+        checks[name] = await page.evaluate(
+          ([fnStr, vw]) => {
+            // eslint-disable-next-line no-new-func
+            const f = new Function('return ' + fnStr)()
+            return f(vw)
+          },
+          [fn.toString(), vp.width]
+        )
+      }
+```
+
+- [ ] **Step 5: Run test, verify passes**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: PASS (11 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/responsive/small-tap-targets.html \
+        tests/utils/responsive-scorer.test.js \
+        scripts/utils/responsive-scorer.js
+git commit -m "feat(responsive): tapTargetFailures check (mobile/tablet only)"
+```
+
+---
+
+## Task 7: lineLengthFailures check
+
+**Files:**
+- Create: `tests/fixtures/responsive/long-lines.html`
+- Modify: `tests/utils/responsive-scorer.test.js`
+- Modify: `scripts/utils/responsive-scorer.js`
+
+- [ ] **Step 1: Write failure fixture**
+
+Write `tests/fixtures/responsive/long-lines.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style>body{font-family:monospace;font-size:12px;margin:0;padding:16px;max-width:none}p{margin:0}</style></head>
+<body>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+</body>
+</html>
+```
+
+At 1440px with small monospace, this will render as one line > 75 chars.
+
+- [ ] **Step 2: Add failing test**
+
+```js
+  describe('lineLengthFailures check', () => {
+    it('flags paragraphs with average line length > 75 chars', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('long-lines.html'),
+        [{ name: 'desktop', width: 1440, height: 900 }],
+        { browser }
+      )
+      expect(metrics.viewports.desktop.checks.lineLengthFailures.length).toBeGreaterThan(0)
+    }, 30_000)
+
+    it('passes when max-width constrains lines', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'desktop', width: 1440, height: 900 }],
+        { browser }
+      )
+      expect(metrics.viewports.desktop.checks.lineLengthFailures).toEqual([])
+    }, 30_000)
+  })
+```
+
+- [ ] **Step 3: Run test, verify failure**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: FAIL.
+
+- [ ] **Step 4: Add check**
+
+Extend `CHECKS`:
+
+```js
+  lineLengthFailures: () => {
+    // Approximate: chars per paragraph / rendered line count.
+    // Rendered lines ≈ clientHeight / computed line-height.
+    const out = []
+    for (const p of document.querySelectorAll('p')) {
+      const text = (p.textContent || '').trim()
+      if (text.length < 100) continue
+      const cs = getComputedStyle(p)
+      const lh = parseFloat(cs.lineHeight) ||
+                 (parseFloat(cs.fontSize) * 1.5)
+      const lines = Math.max(1, Math.round(p.clientHeight / lh))
+      const avgChars = text.length / lines
+      if (avgChars > 75) {
+        out.push({
+          chars: text.length,
+          lines,
+          avgPerLine: Math.round(avgChars),
+          excerpt: text.slice(0, 40),
+        })
+      }
+    }
+    return out
+  },
+```
+
+- [ ] **Step 5: Run test, verify passes**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: PASS (13 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/responsive/long-lines.html \
+        tests/utils/responsive-scorer.test.js \
+        scripts/utils/responsive-scorer.js
+git commit -m "feat(responsive): lineLengthFailures check"
+```
+
+---
+
+## Task 8: Per-viewport scoring and overallScore aggregation
+
+**Files:**
+- Modify: `tests/utils/responsive-scorer.test.js`
+- Modify: `scripts/utils/responsive-scorer.js`
+
+- [ ] **Step 1: Write failing test for scoring math**
+
+Append:
+
+```js
+  describe('scoring math', () => {
+    it('clean page scores 5 at every viewport', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [
+          { name: 'mobile', width: 360, height: 640 },
+          { name: 'desktop', width: 1440, height: 900 },
+        ],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.score).toBe(5)
+      expect(metrics.viewports.desktop.score).toBe(5)
+      expect(metrics.overallScore).toBe(5)
+    }, 30_000)
+
+    it('overflow page scores <5 at mobile and overall = min(viewports)', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('overflow-horizontal.html'),
+        [
+          { name: 'mobile', width: 360, height: 640 },
+          { name: 'desktop', width: 1440, height: 900 },
+        ],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.score).toBeLessThan(5)
+      expect(metrics.overallScore).toBe(metrics.viewports.mobile.score)
+    }, 30_000)
+
+    it('emits worstFailure for bad build', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('overflow-horizontal.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.worstFailure).toBeTruthy()
+      expect(metrics.worstFailure.viewport).toBe('mobile')
+      expect(metrics.worstFailure.check).toBeTruthy()
+    }, 30_000)
+  })
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: FAIL — `score`, `overallScore`, `worstFailure` not emitted.
+
+- [ ] **Step 3: Add scoring to implementation**
+
+In `scripts/utils/responsive-scorer.js`, replace the return statement with full scoring:
+
+```js
+/**
+ * Count failures for a viewport's checks.
+ */
+function countFailures(checks) {
+  let n = 0
+  if (checks.horizontalScroll) n++
+  if (Array.isArray(checks.clippedElements) && checks.clippedElements.length) n++
+  if (Array.isArray(checks.headerOverlap) && checks.headerOverlap.length) n++
+  if (checks.bodyTextSize && checks.bodyTextSize.passing === false) n++
+  if (Array.isArray(checks.tapTargetFailures) && checks.tapTargetFailures.length) n++
+  if (Array.isArray(checks.lineLengthFailures) && checks.lineLengthFailures.length) n++
+  return n
+}
+
+/** failure count → 1..5 (inverted, capped at 4+ failures = 1) */
+function scoreFromFailureCount(n) {
+  if (n === 0) return 5
+  if (n === 1) return 4
+  if (n === 2) return 3
+  if (n === 3) return 2
+  return 1
+}
+
+/** Pick the first failing check type (for worstFailure reporting) */
+function firstFailingCheck(checks) {
+  if (checks.horizontalScroll) return 'horizontalScroll'
+  if (checks.clippedElements?.length) return 'clippedElements'
+  if (checks.headerOverlap?.length) return 'headerOverlap'
+  if (checks.bodyTextSize?.passing === false) return 'bodyTextSize'
+  if (checks.tapTargetFailures?.length) return 'tapTargetFailures'
+  if (checks.lineLengthFailures?.length) return 'lineLengthFailures'
+  return null
+}
+
+function formatFailureDetail(check, viewportResult) {
+  const c = viewportResult.checks
+  switch (check) {
+    case 'horizontalScroll':
+      return `document.scrollWidth exceeded viewport ${viewportResult.width}px`
+    case 'clippedElements':
+      return `${c.clippedElements.length} element(s) extended past the viewport (first: <${c.clippedElements[0].tag}>)`
+    case 'headerOverlap':
+      return `${c.headerOverlap.length} overlapping pair(s) in the header`
+    case 'bodyTextSize':
+      return `body text min ${c.bodyTextSize.min}px (floor 16px)`
+    case 'tapTargetFailures':
+      return `${c.tapTargetFailures.length} interactive element(s) below 44×44px`
+    case 'lineLengthFailures':
+      return `${c.lineLengthFailures.length} paragraph(s) over 75 chars per line`
+    default:
+      return 'unknown'
+  }
+}
+```
+
+Inside the scoring loop, after the `checks` are collected:
+
+```js
+      viewportResults[vp.name] = {
+        width: vp.width,
+        height: vp.height,
+        checks,
+        score: scoreFromFailureCount(countFailures(checks)),
+      }
+```
+
+After the viewport loop, add overall + worstFailure:
+
+```js
+    const overallScore = Math.min(
+      ...Object.values(viewportResults).map(v => v.score)
+    )
+
+    let worstFailure = null
+    const worstVp = Object.entries(viewportResults)
+      .sort(([, a], [, b]) => a.score - b.score)[0]
+    if (worstVp && worstVp[1].score < 5) {
+      const [vpName, vpResult] = worstVp
+      const check = firstFailingCheck(vpResult.checks)
+      if (check) {
+        worstFailure = {
+          viewport: vpName,
+          check,
+          detail: formatFailureDetail(check, vpResult),
+        }
+      }
+    }
+
+    await page.close()
+    return { viewports: viewportResults, overallScore, worstFailure }
+```
+
+- [ ] **Step 4: Run test, verify passes**
+
+Run: `pnpm test tests/utils/responsive-scorer.test.js`
+Expected: PASS (16 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/utils/responsive-scorer.test.js scripts/utils/responsive-scorer.js
+git commit -m "feat(responsive): per-viewport score + overallScore + worstFailure"
+```
+
+---
+
+## Task 9: viewport-screenshotter.js
+
+**Files:**
+- Create: `scripts/utils/viewport-screenshotter.js`
+- Create: `tests/scripts/viewport-screenshotter.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+Write `tests/scripts/viewport-screenshotter.test.js`:
+
+```js
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtemp, rm, stat } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { screenshotViewports } from '../../scripts/utils/viewport-screenshotter.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLEAN = `file://${path.join(__dirname, '../fixtures/responsive/clean.html')}`
+
+describe('viewport-screenshotter', () => {
+  let outDir
+  beforeAll(async () => {
+    outDir = await mkdtemp(path.join(tmpdir(), 'vpscreen-'))
+  })
+  afterAll(async () => {
+    await rm(outDir, { recursive: true, force: true })
+  })
+
+  it('writes one PNG per viewport', async () => {
+    const viewports = [
+      { name: 'mobile', width: 360, height: 640 },
+      { name: 'tablet', width: 768, height: 1024 },
+    ]
+    const results = await screenshotViewports(CLEAN, viewports, outDir)
+    expect(results.length).toBe(2)
+    for (const r of results) {
+      const s = await stat(r.path)
+      expect(s.size).toBeGreaterThan(500)
+      expect(r.path.endsWith(`${r.name}.png`)).toBe(true)
+    }
+  }, 30_000)
+})
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm test tests/scripts/viewport-screenshotter.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+Write `scripts/utils/viewport-screenshotter.js`:
+
+```js
+import { chromium } from '@playwright/test'
+import path from 'path'
+
+/**
+ * Screenshot a URL at multiple viewports.
+ * Single browser, one page, resize between viewports.
+ *
+ * @param {string} url
+ * @param {Array<{name: string, width: number, height: number}>} viewports
+ * @param {string} outDir - absolute path; must exist
+ * @param {object} [opts]
+ * @param {import('@playwright/test').Browser} [opts.browser]
+ * @returns {Promise<Array<{name, width, height, path}>>}
+ */
+export async function screenshotViewports(url, viewports, outDir, opts = {}) {
+  const ownBrowser = !opts.browser
+  const browser = opts.browser || (await chromium.launch({ headless: true }))
+
+  try {
+    const page = await browser.newPage()
+    const results = []
+    for (const vp of viewports) {
+      await page.setViewportSize({ width: vp.width, height: vp.height })
+      await page.goto(url, { waitUntil: 'networkidle' })
+      await page.waitForTimeout(500)
+      const outPath = path.join(outDir, `${vp.name}.png`)
+      await page.screenshot({ path: outPath, type: 'png', fullPage: false })
+      results.push({ name: vp.name, width: vp.width, height: vp.height, path: outPath })
+    }
+    await page.close()
+    return results
+  } finally {
+    if (ownBrowser) await browser.close()
+  }
+}
+```
+
+- [ ] **Step 4: Run test, verify passes**
+
+Run: `pnpm test tests/scripts/viewport-screenshotter.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/utils/viewport-screenshotter.js \
+        tests/scripts/viewport-screenshotter.test.js
+git commit -m "feat(responsive): viewport-screenshotter (Playwright, 4 viewports)"
+```
+
+---
+
+## Task 10: Wire measurement into daily-redesign.js
+
+**Files:**
+- Modify: `scripts/daily-redesign.js`
+
+- [ ] **Step 1: Locate the post-build archive section**
+
+Run: `grep -n "captureSnapshot\|archive(" scripts/daily-redesign.js`
+Note the line numbers where snapshot / archive happen after the build step.
+
+- [ ] **Step 2: Add imports near the top of `scripts/daily-redesign.js`**
+
+```js
+import { screenshotViewports } from './utils/viewport-screenshotter.js'
+import { scoreResponsive } from './utils/responsive-scorer.js'
+```
+
+- [ ] **Step 3: After the existing archive + snapshot call, add scoring**
+
+Find the code that writes files into `buildDir` (the archive build directory). After those writes, add:
+
+```js
+// Responsive measurement — soft-fail, non-blocking.
+try {
+  const previewUrl = 'http://localhost:5173/' // dev server is already up at this point
+  const viewports = [
+    { name: 'mobile',  width: 360,  height: 640 },
+    { name: 'tablet',  width: 768,  height: 1024 },
+    { name: 'laptop',  width: 1024, height: 768 },
+    { name: 'desktop', width: 1440, height: 900 },
+  ]
+  const { chromium } = await import('@playwright/test')
+  const browser = await chromium.launch({ headless: true })
+  try {
+    const screenshotDir = buildDir  // same build dir; filenames {name}.png scoped by viewport
+    // Use sub-dir to avoid collision with existing screenshot.png
+    const { mkdir } = await import('fs/promises')
+    const vpDir = `${buildDir}/viewports`
+    await mkdir(vpDir, { recursive: true })
+    await screenshotViewports(previewUrl, viewports, vpDir, { browser })
+
+    const metrics = await scoreResponsive(previewUrl, viewports, { browser })
+    metrics.buildId = buildId
+    metrics.date = dateStr
+    metrics.archetype = archetype || null
+    metrics.usedInPromptFor = []
+
+    const { writeFile } = await import('fs/promises')
+    await writeFile(
+      `${buildDir}/responsive-metrics.json`,
+      JSON.stringify(metrics, null, 2),
+      'utf8'
+    )
+    console.log(`  responsive metrics written (overall ${metrics.overallScore}/5)`)
+  } finally {
+    await browser.close()
+  }
+} catch (err) {
+  console.warn(`  responsive scoring failed (non-blocking): ${err.message}`)
+}
+```
+
+Note: `buildId`, `dateStr`, `archetype`, `buildDir` must be in scope. If the existing code uses different names, adapt accordingly — the intent is "after we've built the site and archived it, also measure it."
+
+- [ ] **Step 4: Manual smoke test**
+
+Trigger one daily redesign locally:
+```bash
+pnpm --filter=none node scripts/daily-redesign.js --dry-run 2>&1 | tail -20
+```
+
+(Or whatever the project's manual-run command is — check `package.json` scripts.)
+
+Expected: `responsive metrics written (overall N/5)` appears in output; the latest build dir under `archive/` contains `responsive-metrics.json` + `viewports/*.png`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/daily-redesign.js
+git commit -m "feat(responsive): score + screenshot every daily build (soft-fail)"
+```
+
+---
+
+## Task 11: archiver.js — copy viewport screenshots to public/archive/
+
+**Files:**
+- Modify: `scripts/utils/archiver.js`
+
+- [ ] **Step 1: Find `copyToPublic()`**
+
+Run: `grep -n "copyToPublic\|public/archive" scripts/utils/archiver.js`
+
+- [ ] **Step 2: Extend `copyToPublic()` to copy viewport PNGs**
+
+After the existing screenshot.png copy and site HTML copy, add:
+
+```js
+  // Copy viewport screenshots (if the build produced them)
+  const vpSrc = path.join(buildDir, 'viewports')
+  if (existsSync(vpSrc)) {
+    const vpDest = path.join(publicBase, dateStr, 'viewports')
+    await mkdir(vpDest, { recursive: true })
+    const vpEntries = await readdir(vpSrc)
+    for (const f of vpEntries) {
+      if (f.endsWith('.png')) {
+        await copyFile(path.join(vpSrc, f), path.join(vpDest, f))
+      }
+    }
+    console.log(`  copied viewport screenshots to public/archive/${dateStr}/viewports/`)
+  }
+```
+
+- [ ] **Step 3: Manual smoke test**
+
+Re-run a build locally as in Task 10 Step 4. Verify:
+```bash
+ls public/archive/YYYY-MM-DD/viewports/
+```
+Expected: 4 PNGs (mobile.png, tablet.png, laptop.png, desktop.png).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/utils/archiver.js
+git commit -m "feat(responsive): copy viewport PNGs to public/archive/"
+```
+
+---
+
+# Phase 2: Prompt layer
+
+## Task 12: Add responsive section to unified-designer.md
+
+**Files:**
+- Modify: `scripts/prompts/unified-designer.md`
+
+- [ ] **Step 1: Locate insertion point**
+
+Run: `grep -n "^## " scripts/prompts/unified-designer.md`
+Find the line number of `## Accessibility` and `## Required Files`. New section goes between them.
+
+- [ ] **Step 2: Insert responsive section**
+
+Insert (before `## Required Files`, after the accessibility section ends):
+
+```markdown
+## Responsive — Mobile-First, Not Desktop-Squashed
+
+You are designing for three characters: phone (360px), tablet (768px), laptop/desktop (1024px / 1440px). Start your composition at 360px and enhance upward. A design that looks great on desktop but overflows or clips on mobile is a failed build regardless of how striking the desktop view is.
+
+**Mobile-first means:**
+- Default CSS targets 360px. Use `@media (min-width: ...)` to add complexity at larger widths — never subtract at smaller.
+- Large type uses `clamp()` or `vw` with caps, not fixed px. A specimen-scale hero at 120px on desktop should collapse to ~48px on mobile.
+- Fixed sidebars, multi-column grids, and persistent nav rails must have a collapse strategy below the tablet breakpoint (usually stacking into a single column).
+- Header chrome (logo + nav + signals) must not overlap at 360px. If everything can't fit, stack or hide behind a toggle.
+- Touch targets ≥ 44×44px on any viewport ≤ 768px.
+- Body text ≥ 16px at all viewports.
+- Line length ≤ 75 characters at all viewports.
+
+**What gets checked automatically:**
+Every build runs at 360 / 768 / 1024 / 1440 and is scored on: horizontal scroll, content clipping, header overlap, body text size, tap-target size, line length. Failures are logged and fed back into tomorrow's prompt as negative examples.
+
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/prompts/unified-designer.md
+git commit -m "feat(prompt): mobile-first responsive section in unified-designer"
+```
+
+---
+
+## Task 13: Per-seed mobile strategies
+
+**Files:**
+- Modify: `scripts/prompts/seeds/specimen.md`
+- Modify: `scripts/prompts/seeds/broadsheet.md`
+- Modify: `scripts/prompts/seeds/gallery-wall.md`
+- Modify: `scripts/prompts/seeds/split.md`
+- Modify: `scripts/prompts/seeds/scroll.md`
+- Modify: `scripts/prompts/seeds/stack.md`
+- Modify: `scripts/prompts/seeds/poster.md`
+- Modify: `scripts/prompts/seeds/index.md`
+
+- [ ] **Step 1: Append the mobile strategy block to each seed file**
+
+Each file gets a section appended at the end. Exact content per seed:
+
+**specimen.md:**
+```markdown
+
+## Mobile strategy
+
+Specimen fills the full viewport width on mobile; the label block (metadata, callouts, signals) stacks **below** the specimen, not beside. Hero type uses `font-size: clamp(3rem, 14vw, 11.25rem)` so the specimen-scale character survives shrinking without overflow. The specimen element itself should be ≥ 60% of viewport height on mobile — don't let it collapse into something indistinguishable from normal body content.
+```
+
+**broadsheet.md:**
+```markdown
+
+## Mobile strategy
+
+Masthead stacks vertically on mobile: logo → name (Playfair, smaller) → nav as a pill row → date. Columns collapse to a single column with section dividers styled like masthead rules (full-width horizontal lines, not gutters). Datelines and kickers stay visible; they define the archetype.
+```
+
+**gallery-wall.md:**
+```markdown
+
+## Mobile strategy
+
+Wall becomes a vertical scroll of framed artifacts on mobile. Each artifact keeps its scale *relative* to viewport width (e.g. 80vw for featured pieces, 60vw for thumbnails) rather than absolute pixels. The curator's logic should still read — don't just list items end to end; keep the varied rhythm.
+```
+
+**split.md:**
+```markdown
+
+## Mobile strategy
+
+Two halves become two stacked sections on mobile. The divider becomes a horizontal rule (or negative space between sections). Asymmetry carries via aspect-ratio difference — the dominant half gets more vertical space. Avoid flipping which half dominates between viewports.
+```
+
+**scroll.md:**
+```markdown
+
+## Mobile strategy
+
+Already fluid by nature. Ensure signal marginalia (weather, scores, quotes) collapses to **inline** captions or small-caps labels, not floating pull-quotes. Don't place marginalia in the margin at 360px — there is no margin. Tuck them between content beats instead.
+```
+
+**stack.md:**
+```markdown
+
+## Mobile strategy
+
+Already naturally mobile-friendly. Use `min-height` tokens that scale down — no `height: 100vh` without a mobile fallback like `min-height: 500px`. Bands should stack with clear visual breaks at all widths.
+```
+
+**poster.md:**
+```markdown
+
+## Mobile strategy
+
+Retains single dominant element on mobile — scale the hero via `clamp()`. Secondary info (nav, metadata, footer) stays anchored to the poster's bottom, not fighting the hero. If the hero needs to reflow (e.g. "DOUG / MARCH" instead of "DOUG MARCH"), the reflow should look intentional, not cramped.
+```
+
+**index.md:**
+```markdown
+
+## Mobile strategy
+
+Table rows collapse to stacked cards at ≤ 768px. Year / role / description become inline labels within each card, not adjacent columns. The overall "index" character is preserved by keeping consistent row rhythm and visible row numbers or bullets.
+```
+
+Run this to check all seed files exist first:
+
+```bash
+ls scripts/prompts/seeds/
+```
+
+If any seed file is missing from the list above, skip that one and note it — the plan assumes all 8 exist.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/prompts/seeds/
+git commit -m "feat(prompt): mobile strategy in every archetype seed"
+```
+
+---
+
+# Phase 3: /dev rating card
+
+## Task 14: Server function `readResponsiveMetrics`
+
+**Files:**
+- Modify: `app/server/archive-impl.ts`
+
+- [ ] **Step 1: Locate file**
+
+Run: `grep -n "^export\|function" app/server/archive-impl.ts | head -20`
+
+- [ ] **Step 2: Add function**
+
+Append:
+
+```ts
+/**
+ * Read responsive-metrics.json for a given build.
+ * Returns null if the file doesn't exist.
+ */
+export async function readResponsiveMetrics(date: string, buildId: string): Promise<any | null> {
+  const p = `archive/${date}/build-${buildId}/responsive-metrics.json`
+  try {
+    const { readFile } = await import('fs/promises')
+    const raw = await readFile(p, 'utf8')
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+```
+
+- [ ] **Step 3: Add a server route exposing it**
+
+Find the pattern used by other server functions in this file. If there's a TanStack server-function wrapper (`createServerFn`), use it; otherwise expose as a route at `/api/dev-responsive/:date/:buildId`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/server/archive-impl.ts
+git commit -m "feat(responsive): readResponsiveMetrics server function"
+```
+
+---
+
+## Task 15: ResponsiveCard component
+
+**Files:**
+- Create: `app/components/responsive-card.tsx`
+- Modify: `app/dev-panel.tsx`
+
+- [ ] **Step 1: Write component**
+
+Write `app/components/responsive-card.tsx`:
+
+```tsx
+import React from 'react'
+
+type CheckResults = {
+  horizontalScroll?: boolean
+  clippedElements?: Array<{ tag: string; text: string }>
+  headerOverlap?: Array<{ a: string; b: string }>
+  bodyTextSize?: { min: number | null; passing: boolean }
+  tapTargetFailures?: Array<{ tag: string; text: string; w: number; h: number }>
+  lineLengthFailures?: Array<{ chars: number; lines: number; avgPerLine: number }>
+}
+
+type ViewportResult = {
+  width: number
+  height: number
+  checks: CheckResults
+  score: number
+}
+
+export type ResponsiveMetrics = {
+  buildId: string
+  date: string
+  archetype: string | null
+  viewports: Record<string, ViewportResult>
+  overallScore: number
+  worstFailure: { viewport: string; check: string; detail: string } | null
+}
+
+export function ResponsiveCard({ metrics, date }: { metrics: ResponsiveMetrics | null; date: string }) {
+  if (!metrics) return null
+
+  const c = {
+    bg: '#0e1014', border: '#2a2f36', muted: '#8a8f97',
+    text: '#dce0e6', cyan: '#00e5ff', font: 'JetBrains Mono, monospace',
+  }
+  const order: Array<keyof typeof metrics.viewports> = ['mobile', 'tablet', 'laptop', 'desktop']
+  const base = `/archive/${date}/viewports`
+
+  return (
+    <div style={{ border: `1px solid ${c.border}`, padding: 12, marginBottom: 12, fontFamily: c.font, fontSize: 11, color: c.text, background: c.bg }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
+        <strong>Responsive Score</strong>
+        <span style={{ color: c.cyan, fontWeight: 700 }}>{metrics.overallScore} / 5</span>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
+        {order.map(name => {
+          const v = metrics.viewports[name as string]
+          if (!v) return null
+          return (
+            <div key={name as string} style={{ border: `1px solid ${c.border}`, padding: 6 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: c.muted, marginBottom: 4 }}>
+                <span>{name} {v.width}</span>
+                <span>{v.score}/5</span>
+              </div>
+              <a href={`${base}/${name}.png`} target="_blank" rel="noreferrer">
+                <img src={`${base}/${name}.png`} style={{ width: '100%', height: 'auto', display: 'block' }} />
+              </a>
+            </div>
+          )
+        })}
+      </div>
+      {metrics.worstFailure && (
+        <div style={{ marginTop: 8, padding: 8, border: `1px solid ${c.border}`, color: c.muted }}>
+          <strong style={{ color: c.text }}>{metrics.worstFailure.viewport}</strong>{' '}
+          — {metrics.worstFailure.check}: {metrics.worstFailure.detail}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Render in dev-panel.tsx**
+
+Open `app/dev-panel.tsx`. Find where the build's rating inputs begin (search for `ratingCategories`). Add just before that block:
+
+```tsx
+import { ResponsiveCard } from './components/responsive-card'
+```
+at top of file, and inline:
+
+```tsx
+<ResponsiveCard metrics={responsiveMetrics} date={ratingDate} />
+```
+
+Load `responsiveMetrics` via the server function from Task 14. Pattern: if the existing code uses a `useEffect` + fetch pattern for build data, follow it; if it uses TanStack query, use that.
+
+- [ ] **Step 3: Manual smoke test**
+
+Run dev server, navigate to /dev, select a build that has `responsive-metrics.json`. Expect: card appears above rating inputs, 4 thumbnails, failure line if applicable.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/responsive-card.tsx app/dev-panel.tsx
+git commit -m "feat(dev): responsive card in rating panel"
+```
+
+---
+
+# Phase 4: Feedback loop
+
+## Task 16: readResponsiveHistory helper
+
+**Files:**
+- Create: `scripts/utils/read-responsive-history.js`
+- Create: `tests/utils/read-responsive-history.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+Write `tests/utils/read-responsive-history.test.js`:
+
+```js
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { readResponsiveHistory } from '../../scripts/utils/read-responsive-history.js'
+
+describe('readResponsiveHistory', () => {
+  let root
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'rh-'))
+  })
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  async function plantBuild(date, buildId, metrics) {
+    const dir = path.join(root, 'archive', date, `build-${buildId}`)
+    await mkdir(dir, { recursive: true })
+    await writeFile(path.join(dir, 'responsive-metrics.json'), JSON.stringify(metrics))
+  }
+
+  it('returns empty array when no archive exists', async () => {
+    expect(await readResponsiveHistory({ root, limit: 10 })).toEqual([])
+  })
+
+  it('reads metrics across multiple dates, newest first', async () => {
+    await plantBuild('2026-04-10', '1', { buildId: '1', overallScore: 3 })
+    await plantBuild('2026-04-12', '2', { buildId: '2', overallScore: 5 })
+    await plantBuild('2026-04-11', '3', { buildId: '3', overallScore: 4 })
+    const h = await readResponsiveHistory({ root, limit: 10 })
+    expect(h.map(m => m.buildId)).toEqual(['2', '3', '1'])
+  })
+
+  it('respects limit', async () => {
+    await plantBuild('2026-04-10', '1', { buildId: '1', overallScore: 3 })
+    await plantBuild('2026-04-11', '2', { buildId: '2', overallScore: 5 })
+    await plantBuild('2026-04-12', '3', { buildId: '3', overallScore: 4 })
+    const h = await readResponsiveHistory({ root, limit: 2 })
+    expect(h.length).toBe(2)
+    expect(h[0].buildId).toBe('3')
+  })
+})
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm test tests/utils/read-responsive-history.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+Write `scripts/utils/read-responsive-history.js`:
+
+```js
+import { readdir, readFile, stat } from 'fs/promises'
+import path from 'path'
+
+/**
+ * Read recent responsive-metrics.json files across archive dirs.
+ * Returned newest-first, limited to `limit` builds.
+ *
+ * @param {object} opts
+ * @param {string} opts.root - project root (defaults to cwd)
+ * @param {number} [opts.limit=30]
+ * @returns {Promise<Array<object>>}
+ */
+export async function readResponsiveHistory({ root = process.cwd(), limit = 30 } = {}) {
+  const archiveRoot = path.join(root, 'archive')
+  let dates
+  try {
+    dates = (await readdir(archiveRoot)).filter(d => /^\d{4}-\d{2}-\d{2}$/.test(d))
+  } catch {
+    return []
+  }
+  dates.sort().reverse()
+
+  const out = []
+  for (const date of dates) {
+    const dateDir = path.join(archiveRoot, date)
+    let builds
+    try {
+      builds = (await readdir(dateDir)).filter(b => b.startsWith('build-'))
+    } catch { continue }
+    builds.sort().reverse()
+    for (const b of builds) {
+      const p = path.join(dateDir, b, 'responsive-metrics.json')
+      try {
+        const raw = await readFile(p, 'utf8')
+        out.push(JSON.parse(raw))
+      } catch { /* missing or invalid — skip */ }
+      if (out.length >= limit) return out
+    }
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: Run test, verify passes**
+
+Run: `pnpm test tests/utils/read-responsive-history.test.js`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/utils/read-responsive-history.js tests/utils/read-responsive-history.test.js
+git commit -m "feat(responsive): readResponsiveHistory utility"
+```
+
+---
+
+## Task 17: prompt-feedback-selector
+
+**Files:**
+- Create: `scripts/utils/prompt-feedback-selector.js`
+- Create: `tests/utils/prompt-feedback-selector.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Write `tests/utils/prompt-feedback-selector.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { selectRecentFailure } from '../../scripts/utils/prompt-feedback-selector.js'
+
+function build(overrides) {
+  return {
+    buildId: 'b',
+    date: '2026-04-10',
+    archetype: 'Specimen',
+    overallScore: 2,
+    worstFailure: { viewport: 'mobile', check: 'horizontalScroll', detail: 'x' },
+    usedInPromptFor: [],
+    ...overrides,
+  }
+}
+
+describe('selectRecentFailure', () => {
+  it('returns null on cold-start (<3 builds)', () => {
+    const r = selectRecentFailure({ history: [build({}), build({})], todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.lesson).toBeNull()
+  })
+
+  it('prefers matching archetype', () => {
+    const history = [
+      build({ buildId: 'old-gw', archetype: 'Gallery Wall' }),
+      build({ buildId: 'old-sp', archetype: 'Specimen', date: '2026-04-14' }),
+      build({ buildId: 'old-sc', archetype: 'Scroll' }),
+    ]
+    const r = selectRecentFailure({ history, todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.lesson).toContain('2026-04-14')
+    expect(r.selectedBuildId).toBe('old-sp')
+  })
+
+  it('falls back to any archetype when none match', () => {
+    const history = [
+      build({ buildId: 'old-gw', archetype: 'Gallery Wall' }),
+      build({ buildId: 'old-sc', archetype: 'Scroll' }),
+      build({ buildId: 'old-st', archetype: 'Stack' }),
+    ]
+    const r = selectRecentFailure({ history, todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.lesson).toBeTruthy()
+  })
+
+  it('skips builds where usedInPromptFor >= 2', () => {
+    const history = [
+      build({ buildId: 'used', usedInPromptFor: ['2026-04-15', '2026-04-16'] }),
+      build({ buildId: 'a' }),
+      build({ buildId: 'b' }),
+    ]
+    const r = selectRecentFailure({ history, todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.selectedBuildId).not.toBe('used')
+  })
+
+  it('returns null when all passing (no overallScore ≤ 3)', () => {
+    const history = [
+      build({ overallScore: 5 }),
+      build({ overallScore: 5 }),
+      build({ overallScore: 4 }),
+    ]
+    const r = selectRecentFailure({ history, todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.lesson).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `pnpm test tests/utils/prompt-feedback-selector.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write implementation**
+
+Write `scripts/utils/prompt-feedback-selector.js`:
+
+```js
+/**
+ * Format a cautionary lesson from a chosen build's worstFailure.
+ */
+function formatLesson(b) {
+  const f = b.worstFailure
+  return [
+    `Recent lesson (${b.date}, ${b.archetype || 'unknown'} archetype, ${f.viewport} score ${b.viewports?.[f.viewport]?.score ?? '?'}/5):`,
+    '',
+    `The ${f.check} check failed: ${f.detail}.`,
+    '',
+    'Apply the mobile-first rules above to avoid repeating this pattern.',
+  ].join('\n')
+}
+
+/**
+ * Pick a recent failing build to inject as a lesson in today's prompt.
+ *
+ * @param {object} opts
+ * @param {Array<object>} opts.history - recent builds, newest-first (expected from readResponsiveHistory)
+ * @param {string} opts.todayArchetype
+ * @param {string} opts.today - ISO date of today's build
+ * @returns {{ lesson: string|null, selectedBuildId: string|null }}
+ */
+export function selectRecentFailure({ history, todayArchetype, today }) {
+  const recent = history.slice(0, 7)
+  if (recent.length < 3) return { lesson: null, selectedBuildId: null }
+
+  const eligible = recent.filter(b =>
+    typeof b.overallScore === 'number' && b.overallScore <= 3 &&
+    (Array.isArray(b.usedInPromptFor) ? b.usedInPromptFor.length < 2 : true) &&
+    b.worstFailure
+  )
+  if (eligible.length === 0) return { lesson: null, selectedBuildId: null }
+
+  // Prefer matching archetype
+  const matching = eligible.find(b => b.archetype === todayArchetype)
+  const chosen = matching || eligible[0]
+
+  return { lesson: formatLesson(chosen), selectedBuildId: chosen.buildId }
+}
+```
+
+- [ ] **Step 4: Run test, verify passes**
+
+Run: `pnpm test tests/utils/prompt-feedback-selector.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/utils/prompt-feedback-selector.js tests/utils/prompt-feedback-selector.test.js
+git commit -m "feat(responsive): prompt-feedback-selector (archetype-scoped, reuse-capped)"
+```
+
+---
+
+## Task 18: Wire selector into prompt-builder (gated by env var)
+
+**Files:**
+- Modify: `scripts/utils/prompt-builder.js`
+
+- [ ] **Step 1: Find unified-designer user-prompt assembly**
+
+Run: `grep -n "unified-designer\|userPrompt\|COLOR_MANDATE\|colorMandate" scripts/utils/prompt-builder.js | head -20`
+
+Find where `colorMandate` is injected (recent work from the color-mandate branch).
+
+- [ ] **Step 2: Add imports + injection**
+
+Near the top of `scripts/utils/prompt-builder.js`:
+
+```js
+import { readResponsiveHistory } from './read-responsive-history.js'
+import { selectRecentFailure } from './prompt-feedback-selector.js'
+```
+
+Near the colorMandate injection, add:
+
+```js
+// Gated behind env var — only inject when the feedback loop is enabled.
+if (process.env.RESPONSIVE_FEEDBACK_LOOP === '1') {
+  try {
+    const history = await readResponsiveHistory({ limit: 7 })
+    const today = new Date().toISOString().slice(0, 10)
+    const { lesson, selectedBuildId } = selectRecentFailure({
+      history,
+      todayArchetype: archetype,  // assumes `archetype` is in scope where this prompt is built
+      today,
+    })
+    if (lesson) {
+      userPrompt += `\n\n## Lesson from Recent Builds\n\n${lesson}`
+
+      // Mark the chosen build as used for this date so we don't reuse it forever.
+      if (selectedBuildId) {
+        const { writeFile, readFile } = await import('fs/promises')
+        const b = history.find(x => x.buildId === selectedBuildId)
+        if (b) {
+          const p = `archive/${b.date}/build-${b.buildId}/responsive-metrics.json`
+          const raw = JSON.parse(await readFile(p, 'utf8'))
+          raw.usedInPromptFor = [...(raw.usedInPromptFor || []), today]
+          await writeFile(p, JSON.stringify(raw, null, 2), 'utf8')
+        }
+      }
+    }
+  } catch (err) {
+    console.warn(`  responsive feedback injection failed (non-blocking): ${err.message}`)
+  }
+}
+```
+
+- [ ] **Step 3: Manual smoke test**
+
+With `RESPONSIVE_FEEDBACK_LOOP=1` and at least 3 prior builds containing `responsive-metrics.json` (at least one with overallScore ≤ 3), trigger a build. Inspect the prompt log — it should contain `## Lesson from Recent Builds`. Then check the selected build's `responsive-metrics.json` — `usedInPromptFor` should now include today's date.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/utils/prompt-builder.js
+git commit -m "feat(responsive): feedback loop — inject recent lesson into prompt (env-gated)"
+```
+
+---
+
+# Phase 5: Trend dashboard
+
+## Task 19: /dev/responsive route + inline SVG charts
+
+**Files:**
+- Create: `app/routes/dev.responsive.tsx`
+- Create: `app/components/responsive-trend.tsx`
+- Modify: `app/server/archive-impl.ts` (add history reader for server side)
+
+- [ ] **Step 1: Expose readResponsiveHistory on the server**
+
+In `app/server/archive-impl.ts`, add:
+
+```ts
+/**
+ * Read recent builds' responsive-metrics.json for the trend dashboard.
+ */
+export async function readResponsiveHistoryServer(limit = 30): Promise<any[]> {
+  // Thin adapter around scripts/utils/read-responsive-history.js for TanStack server use.
+  const mod = await import('../../scripts/utils/read-responsive-history.js')
+  return mod.readResponsiveHistory({ limit })
+}
+```
+
+- [ ] **Step 2: Write the route**
+
+Write `app/routes/dev.responsive.tsx`:
+
+```tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { ResponsiveTrend } from '../components/responsive-trend'
+import { readResponsiveHistoryServer } from '../server/archive-impl'
+
+export const Route = createFileRoute('/dev/responsive')({
+  component: ResponsivePage,
+  loader: async () => ({
+    history: await readResponsiveHistoryServer(30),
+  }),
+})
+
+function ResponsivePage() {
+  const { history } = Route.useLoaderData()
+  return (
+    <div style={{ padding: 16, fontFamily: 'JetBrains Mono, monospace', fontSize: 12, background: '#0e1014', color: '#dce0e6', minHeight: '100vh' }}>
+      <h1 style={{ fontSize: 14, marginBottom: 16 }}>Responsive — last 30 builds</h1>
+      <ResponsiveTrend history={history} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Write the chart component**
+
+Write `app/components/responsive-trend.tsx`:
+
+```tsx
+import React from 'react'
+
+type HistoryItem = {
+  buildId: string
+  date: string
+  archetype: string | null
+  overallScore: number
+  viewports: Record<string, { score: number }>
+  worstFailure?: { check: string } | null
+}
+
+const COLORS = { border: '#2a2f36', muted: '#8a8f97', text: '#dce0e6', cyan: '#00e5ff', fail: '#ff6b6b' }
+
+function LineChart({ data, label }: { data: Array<{ x: number; y: number; labelX?: string }>; label: string }) {
+  const W = 600, H = 120, pad = 24
+  if (data.length === 0) return <div style={{ color: COLORS.muted }}>no data</div>
+  const xs = data.map(d => d.x), ys = data.map(d => d.y)
+  const xMin = Math.min(...xs), xMax = Math.max(...xs)
+  const yMin = 1, yMax = 5
+  const sx = (x: number) => pad + ((x - xMin) / Math.max(1, xMax - xMin)) * (W - pad * 2)
+  const sy = (y: number) => H - pad - ((y - yMin) / (yMax - yMin)) * (H - pad * 2)
+  const poly = data.map(d => `${sx(d.x)},${sy(d.y)}`).join(' ')
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <div style={{ fontSize: 11, color: COLORS.muted, marginBottom: 4 }}>{label}</div>
+      <svg width={W} height={H} style={{ border: `1px solid ${COLORS.border}` }}>
+        <polyline points={poly} fill="none" stroke={COLORS.cyan} strokeWidth={1.5} />
+        {data.map((d, i) => (
+          <circle key={i} cx={sx(d.x)} cy={sy(d.y)} r={2.5} fill={COLORS.cyan}>
+            <title>{`${d.labelX || d.x}: ${d.y}/5`}</title>
+          </circle>
+        ))}
+      </svg>
+    </div>
+  )
+}
+
+function BarChart({ rows }: { rows: Array<{ label: string; count: number }> }) {
+  const max = Math.max(1, ...rows.map(r => r.count))
+  return (
+    <div style={{ marginBottom: 16 }}>
+      {rows.map(r => (
+        <div key={r.label} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11, marginBottom: 2 }}>
+          <span style={{ width: 180 }}>{r.label}</span>
+          <div style={{ flex: 1, background: COLORS.border, height: 12, position: 'relative' }}>
+            <div style={{ width: `${(r.count / max) * 100}%`, height: '100%', background: COLORS.fail }} />
+          </div>
+          <span style={{ width: 40, textAlign: 'right', color: COLORS.muted }}>{r.count}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function ResponsiveTrend({ history }: { history: HistoryItem[] }) {
+  // Sort oldest-first for chart
+  const asc = [...history].sort((a, b) => a.date.localeCompare(b.date))
+
+  const overallData = asc.map((h, i) => ({ x: i, y: h.overallScore, labelX: h.date }))
+
+  const perVp = ['mobile', 'tablet', 'laptop', 'desktop']
+  const perVpSeries = perVp.map(name => ({
+    name,
+    data: asc.map((h, i) => ({ x: i, y: h.viewports?.[name]?.score ?? 0, labelX: h.date })),
+  }))
+
+  const failCounts: Record<string, number> = {}
+  for (const h of history) {
+    if (h.worstFailure?.check) failCounts[h.worstFailure.check] = (failCounts[h.worstFailure.check] || 0) + 1
+  }
+  const failRows = Object.entries(failCounts)
+    .sort(([, a], [, b]) => b - a)
+    .map(([label, count]) => ({ label, count }))
+
+  const byArchetype: Record<string, { total: number; n: number }> = {}
+  for (const h of history) {
+    const k = h.archetype || 'unknown'
+    if (!byArchetype[k]) byArchetype[k] = { total: 0, n: 0 }
+    byArchetype[k].total += h.overallScore
+    byArchetype[k].n += 1
+  }
+  const archRows = Object.entries(byArchetype)
+    .map(([k, { total, n }]) => ({ archetype: k, avg: (total / n).toFixed(1), n }))
+    .sort((a, b) => parseFloat(a.avg) - parseFloat(b.avg))
+
+  const worstBuilds = [...history]
+    .filter(h => h.overallScore <= 3)
+    .sort((a, b) => a.overallScore - b.overallScore)
+    .slice(0, 10)
+
+  return (
+    <div>
+      <LineChart data={overallData} label={`Overall score (last ${asc.length} builds)`} />
+      {perVpSeries.map(s => (
+        <LineChart key={s.name} data={s.data} label={`${s.name} score`} />
+      ))}
+
+      <div style={{ fontSize: 11, color: COLORS.muted, marginBottom: 4, marginTop: 16 }}>Failure types</div>
+      <BarChart rows={failRows} />
+
+      <div style={{ fontSize: 11, color: COLORS.muted, marginBottom: 4, marginTop: 16 }}>Worst by archetype</div>
+      <table style={{ fontSize: 11, borderCollapse: 'collapse' }}>
+        <thead><tr><th style={{ textAlign: 'left', padding: 4 }}>archetype</th><th style={{ padding: 4 }}>avg</th><th style={{ padding: 4 }}>n</th></tr></thead>
+        <tbody>{archRows.map(r => (
+          <tr key={r.archetype}><td style={{ padding: 4 }}>{r.archetype}</td><td style={{ padding: 4 }}>{r.avg}</td><td style={{ padding: 4 }}>{r.n}</td></tr>
+        ))}</tbody>
+      </table>
+
+      <div style={{ fontSize: 11, color: COLORS.muted, marginBottom: 4, marginTop: 16 }}>Worst recent builds</div>
+      <ul style={{ fontSize: 11, paddingLeft: 16 }}>
+        {worstBuilds.map(b => (
+          <li key={b.buildId}>
+            <a href={`/dev?date=${b.date}&buildId=${b.buildId}`} style={{ color: COLORS.cyan }}>
+              {b.date} · {b.archetype || '—'} · {b.overallScore}/5
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Manual smoke test**
+
+Navigate to `http://localhost:5173/dev/responsive`. Expect: line chart(s), failure-type bar chart, archetype table, worst-builds list. If there's no history yet, components render with "no data" placeholders or empty states — that's fine.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/routes/dev.responsive.tsx \
+        app/components/responsive-trend.tsx \
+        app/server/archive-impl.ts
+git commit -m "feat(dev): /dev/responsive trend dashboard"
+```
+
+---
+
+## Task 20: E2E tests
+
+**Files:**
+- Create: `tests/e2e/dev-responsive-panel.spec.ts`
+- Create: `tests/e2e/dev-responsive-trend.spec.ts`
+
+- [ ] **Step 1: Write rating-panel e2e test**
+
+Write `tests/e2e/dev-responsive-panel.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test('responsive card renders when metrics exist', async ({ page }) => {
+  // Precondition: there must be at least one build in archive/ with responsive-metrics.json.
+  // CI should plant a fixture before this runs if no natural build exists.
+  await page.goto('/dev')
+
+  const card = page.getByText('Responsive Score').first()
+  await expect(card).toBeVisible({ timeout: 5000 })
+
+  // Four viewport thumbs
+  const thumbs = page.locator('img[src*="/viewports/"]')
+  await expect(thumbs).toHaveCount(4)
+})
+```
+
+- [ ] **Step 2: Write trend e2e test**
+
+Write `tests/e2e/dev-responsive-trend.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test('/dev/responsive renders all sections', async ({ page }) => {
+  await page.goto('/dev/responsive')
+  await expect(page.getByText('Overall score').first()).toBeVisible()
+  await expect(page.getByText('Failure types').first()).toBeVisible()
+  await expect(page.getByText('Worst by archetype').first()).toBeVisible()
+  await expect(page.getByText('Worst recent builds').first()).toBeVisible()
+})
+```
+
+- [ ] **Step 3: Run e2e tests**
+
+Run: `pnpm exec playwright test tests/e2e/dev-responsive-panel.spec.ts tests/e2e/dev-responsive-trend.spec.ts`
+Expected: PASS (or "no metrics yet" skip if archive is empty — note in test results).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/dev-responsive-panel.spec.ts tests/e2e/dev-responsive-trend.spec.ts
+git commit -m "test(responsive): e2e for dev rating card + trend dashboard"
+```
+
+---
+
+## Task 21: Full suite run + push PR
+
+- [ ] **Step 1: Run full unit + integration suite**
+
+Run: `pnpm test`
+Expected: all tests pass (previous 253 + new scorer + screenshotter + history + selector tests).
+
+- [ ] **Step 2: Run e2e suite**
+
+Run: `pnpm exec playwright test`
+Expected: all pass.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin feat/responsive-design
+gh pr create --title "feat: responsive design measurement + feedback loop" --body "$(cat <<'EOF'
+## Summary
+- Measure every daily build at 4 viewports (360 / 768 / 1024 / 1440)
+- Score horizontal overflow, clipping, header overlap, body size, tap targets, line length
+- Inject yesterday's worst failure into today's prompt (gated by RESPONSIVE_FEEDBACK_LOOP=1)
+- New /dev rating card + /dev/responsive trend dashboard
+- Mobile-first responsive section in unified-designer.md + per-seed strategies
+
+Spec: `docs/superpowers/specs/2026-04-17-responsive-design.md`
+Plan: `docs/superpowers/plans/2026-04-17-responsive-design.md`
+
+## Test plan
+- [ ] pnpm test passes (unit + integration)
+- [ ] pnpm exec playwright test passes
+- [ ] Trigger one local daily-redesign — verify responsive-metrics.json written
+- [ ] Enable RESPONSIVE_FEEDBACK_LOOP=1 for one build — verify lesson injection
+- [ ] Load /dev and /dev/responsive — verify rendering
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+After writing this plan:
+
+**Spec coverage:**
+- § Architecture → Tasks 1–11 (measurement), 14–15 (UI), 16–18 (loop), 19 (dashboard) ✓
+- § Prompt Layer → Tasks 12–13 ✓
+- § Measurement Layer → Tasks 1–11 ✓
+- § Surfacing Layer → Tasks 14–15, 19 ✓
+- § Feedback Loop → Tasks 16–18 ✓
+- § Testing Strategy → Tasks 1–9, 16, 17, 20 ✓
+- § Rollout Plan Phase 1–5 → covered by task grouping ✓
+
+**Placeholder scan:** no TBD/TODO found. Each step has actual code or exact commands.
+
+**Type consistency:**
+- `scoreResponsive(url, viewports, opts)` signature consistent across Tasks 2–8 ✓
+- `screenshotViewports(url, viewports, outDir, opts)` signature consistent in Tasks 9 + 10 ✓
+- `selectRecentFailure({ history, todayArchetype, today })` matches Task 17 definition + Task 18 call ✓
+- `readResponsiveHistory({ root, limit })` matches Task 16 definition + Task 18 call ✓
+- `responsive-metrics.json` schema consistent across writer (Task 10), selector (Tasks 16/17), and UI (Tasks 15/19) ✓
+
+**Unused prior agreements:**
+- "Re-score" button in /dev (Section 4 of spec) is NOT in the plan. **Decision:** deferred to future work — backfill for ~6 historical builds is small; we can script it manually once metrics ship. Adding it now inflates Phase 3 scope. Noted in spec as future work via re-score endpoint; plan explicitly does not create `/api/dev-rescore`.

--- a/docs/superpowers/specs/2026-04-17-responsive-design.md
+++ b/docs/superpowers/specs/2026-04-17-responsive-design.md
@@ -1,0 +1,456 @@
+# Responsive Design System — Design Spec
+
+**Date:** 2026-04-17
+**Author:** Doug March + Claude (brainstorming)
+**Branch:** `feat/responsive-design`
+**Status:** Design approved; awaiting implementation plan.
+
+## Problem
+
+The pipeline currently produces designs that are strong on desktop (best:
+24/25 on 2026-04-14 Specimen) but break catastrophically on mobile and
+inconsistently on tablet. Observed failures across the last 6 builds:
+
+- **2026-04-13 Specimen** — "DOUG MARCH" hero overflows 360px, rendering
+  as "DOUG / MARC"
+- **2026-04-17 Index** — fixed left sidebar consumes 40% of 360px
+  viewport; "Spaceman" hero clips horizontally
+- **2026-04-10 Gallery Wall** — header cramming (logo + nav + title +
+  date + pill) produces unreadable overlap at 360px; 3-column grid
+  survives tablet but is clearly not designed for it
+
+Zero responsive guidance exists in any prompt file today. "viewport"
+appears only as metaphor ("first viewport"); no mention of breakpoints,
+`@media`, `clamp()`, or mobile/tablet strategy. The mobile failures are
+not bugs — they are the model doing what it was asked to do.
+
+## Goals
+
+1. Designs look great on mobile (360px), tablet (768px), laptop
+   (1024px), and desktop (1440px) — not just desktop.
+2. Measurement is automatic and continuous — every build is scored.
+3. Failures feed back into tomorrow's prompt so the system improves
+   over time without constant manual prompt edits.
+4. Nothing blocks the pipeline. Soft-fail throughout.
+
+## Non-Goals
+
+- Hard-failing builds on responsive violations. Daily redesign ships
+  regardless; scores inform future prompts and human review.
+- Retooling the chassis / preset system. Responsive is handled in CSS
+  by the designer, not in the token layer.
+- 320px / 1440px+ edge case perfection. Four representative viewports
+  (360, 768, 1024, 1440) are the sample points.
+- Composition judgment ("does the mobile specimen still feel like a
+  specimen?"). That remains a human rating in /dev.
+
+## Design Decisions (locked during brainstorming)
+
+| # | Decision | Chosen |
+|---|---|---|
+| 1 | Enforcement philosophy | Soft-fail + metrics reporting; no build-killer checks |
+| 2 | What counts as broken | Layout integrity (scroll, clipping, overlap) + readability (body size, tap targets, line length) auto-checked; composition stays human-rated |
+| 3 | Breakpoints | Industry-common: 360, 768, 1024, 1440 |
+| 4 | Mobile-first guidance location | `unified-designer.md` **plus** per-seed collapse strategies |
+| 5 | Metrics surface | Archive JSON + /dev panel shows 4 viewport screenshots + new `/dev/responsive` trend dashboard |
+| 6 | Timing | Automatic in pipeline every build + on-demand "Re-score" button for backfill |
+| 7 | Approach | Approach 2 — philosophy + measurement + self-improving prompt feedback loop |
+
+## Architecture
+
+Four new units, each with one clear job:
+
+1. **`viewport-screenshotter`** — given a URL and viewports, produce PNGs.
+   Does not know about scoring or archives.
+2. **`responsive-scorer`** — given a URL and viewports, run DOM
+   inspection and return a metrics object. Does not know about
+   screenshots, archives, or prompt injection.
+3. **`prompt-feedback-selector`** — given a history of metrics JSON,
+   pick a cautionary example to inject into today's prompt. Does not
+   know how scoring works, just reads the output.
+4. **`/dev` UI** — reads metrics + screenshots from disk; pure display.
+
+The metrics JSON schema is the contract between layers. Change a scorer
+rule without touching /dev; change display without touching the
+pipeline.
+
+Data flow:
+
+```
+pipeline → viewport-screenshotter → 4 PNGs + responsive-metrics.json
+                                         ↓
+                      archive/YYYY-MM-DD/build-{id}/
+                      public/archive/YYYY-MM-DD/screenshots/
+                                         ↓
+                         /dev UI (card + trend dashboard)
+                                         ↓
+                 prompt-feedback-selector (next day's prompt)
+```
+
+## Prompt Layer
+
+### Edit 1 — `scripts/prompts/unified-designer.md`
+
+New section slotted after "Accessibility", before "Required Files":
+
+```markdown
+## Responsive — Mobile-First, Not Desktop-Squashed
+
+You are designing for three characters: phone (360px), tablet (768px),
+laptop/desktop (1024px / 1440px). Start your composition at 360px and
+enhance upward. A design that looks great on desktop but overflows or
+clips on mobile is a failed build regardless of how striking the
+desktop view is.
+
+**Mobile-first means:**
+- Default CSS targets 360px. Use `@media (min-width: ...)` to add
+  complexity at larger widths — never subtract at smaller.
+- Large type uses `clamp()` or `vw` with caps, not fixed px. A
+  specimen-scale hero at 120px on desktop should collapse to ~48px on
+  mobile.
+- Fixed sidebars, multi-column grids, and persistent nav rails must
+  have a collapse strategy below the tablet breakpoint (usually
+  stacking into a single column).
+- Header chrome (logo + nav + signals) must not overlap at 360px. If
+  everything can't fit, stack or hide behind a toggle.
+- Touch targets ≥ 44×44px on any viewport ≤ 768px.
+- Body text ≥ 16px at all viewports.
+- Line length ≤ 75 characters at all viewports.
+
+**What gets checked automatically:**
+Every build runs at 360 / 768 / 1024 / 1440 and is scored on:
+horizontal scroll, content clipping, header overlap, body text size,
+tap-target size, line length. Failures are logged and fed back into
+tomorrow's prompt as negative examples.
+```
+
+### Edit 2 — `scripts/utils/prompt-builder.js`
+
+Inject a "Lesson from Recent Builds" section conditionally:
+
+```js
+const recentLesson = await selectRecentFailure({
+  history: await readResponsiveHistory(),
+  today: new Date(),
+})
+if (recentLesson) {
+  userPrompt += `\n\n## Lesson from Recent Builds\n\n${recentLesson}`
+}
+```
+
+### Edit 3 — per-seed collapse strategies
+
+Each archetype seed gains a short (2–4 line) "Mobile strategy" section:
+
+| Seed | Mobile strategy |
+|---|---|
+| **specimen.md** | Specimen fills viewport width; label block stacks below, not beside. Hero type uses `clamp(48px, 14vw, 180px)`. |
+| **broadsheet.md** | Masthead stacks vertically (logo → name → nav pill row → date). Columns collapse to single column with masthead-style rules. |
+| **gallery-wall.md** | Wall becomes a vertical scroll of framed artifacts. Scale is relative to viewport width, not absolute. |
+| **split.md** | Two halves become two stacked sections; divider becomes a horizontal rule. Asymmetry carries via aspect-ratio difference. |
+| **scroll.md** | Signal marginalia collapses to inline captions, not floating pull-quotes. |
+| **stack.md** | Bands use `min-height` tokens that scale down — no `100vh` without a mobile fallback. |
+| **poster.md** | Retains single dominant element; scale hero via `clamp()`. Secondary info stays at poster's bottom. |
+| **index.md** | Table rows collapse to stacked cards at ≤ 768px. Year/role become inline labels, not columns. |
+
+Token-designer.md is untouched. The chassis and preset system stay as
+they are — responsive is handled in CSS by the unified designer, not in
+tokens.
+
+## Measurement Layer
+
+### `scripts/utils/viewport-screenshotter.js`
+
+```js
+/**
+ * Screenshot a URL at multiple viewports.
+ * Reuses a single browser instance; resizes page between viewports.
+ *
+ * @param {string} url
+ * @param {Array<{name, width, height}>} viewports
+ * @param {string} outDir - absolute path
+ * @returns {Promise<Array<{name, width, height, path}>>}
+ */
+export async function screenshotViewports(url, viewports, outDir) { ... }
+```
+
+Does not know about archive dirs, metrics, or scoring. Writes PNGs to
+the directory given. Single `chromium.launch`, one `page.setViewportSize`
+call per viewport (not a new page).
+
+### `scripts/utils/responsive-scorer.js`
+
+```js
+/**
+ * @param {string} url
+ * @param {Array<{name, width, height}>} viewports
+ * @returns {Promise<ResponsiveMetrics>}
+ */
+export async function scoreResponsive(url, viewports) { ... }
+```
+
+Each check runs inside the page context via Playwright:
+
+- **horizontalScroll** — `document.documentElement.scrollWidth > window.innerWidth`
+- **clippedElements** — any element whose `getBoundingClientRect().right`
+  exceeds `window.innerWidth + 1` (the +1 absorbs subpixel rounding)
+- **headerOverlap** — bounding-rect intersection across direct children
+  of the first `<header>` or nav container
+- **bodyTextSize** — minimum computed `font-size` of text nodes inside
+  `<main>` or `<body>`
+- **tapTargetFailures** — `<a>`, `<button>`, `[role=button]` elements
+  with bounding box < 44×44 at viewports ≤ 768
+- **lineLengthFailures** — rendered paragraphs whose line count × line
+  length implies > 75 characters on any line (approximation via
+  `paragraph.textContent.length / visualLines`)
+
+### Metrics JSON schema
+
+Written to `archive/YYYY-MM-DD/build-{id}/responsive-metrics.json`:
+
+```json
+{
+  "buildId": "1776...",
+  "date": "2026-04-17",
+  "archetype": "Specimen",
+  "viewports": {
+    "mobile":  { "width": 360,  "height": 640,  "checks": { ... }, "score": 2 },
+    "tablet":  { "width": 768,  "height": 1024, "checks": { ... }, "score": 4 },
+    "laptop":  { "width": 1024, "height": 768,  "checks": { ... }, "score": 5 },
+    "desktop": { "width": 1440, "height": 900,  "checks": { ... }, "score": 5 }
+  },
+  "overallScore": 2,
+  "worstFailure": {
+    "viewport": "mobile",
+    "check": "horizontalScroll",
+    "detail": "document.scrollWidth was 540, viewport 360 — hero type overflowed",
+    "suggestedCause": "fixed font-size on hero; use clamp()"
+  },
+  "usedInPromptFor": []
+}
+```
+
+- Per-viewport `score` is 1–5, inverted from failure count (0 failures = 5, 1 = 4, 2 = 3, 3 = 2, ≥4 = 1).
+- `overallScore` = minimum across viewports (weak-link metric).
+- `worstFailure` = the single worst individual check; what gets injected into tomorrow's prompt.
+- `usedInPromptFor` = dates where this failure was already injected; used by the feedback selector to avoid repeating.
+
+### Orchestration
+
+In `scripts/daily-redesign.js`, after the existing `captureSnapshot()` call:
+
+```js
+const viewports = [
+  { name: 'mobile',  width: 360,  height: 640 },
+  { name: 'tablet',  width: 768,  height: 1024 },
+  { name: 'laptop',  width: 1024, height: 768 },
+  { name: 'desktop', width: 1440, height: 900 },
+]
+try {
+  await screenshotViewports(previewUrl, viewports, buildDir)
+  const metrics = await scoreResponsive(previewUrl, viewports)
+  await writeFile(
+    path.join(buildDir, 'responsive-metrics.json'),
+    JSON.stringify(metrics, null, 2)
+  )
+} catch (err) {
+  console.warn(`  responsive scoring failed (non-blocking): ${err.message}`)
+}
+```
+
+Non-blocking. Pipeline does not fail if scoring fails.
+
+## Surfacing Layer
+
+### Rating panel card (`app/dev-panel.tsx`)
+
+New card rendered above the existing human rating inputs when
+`responsive-metrics.json` exists for the selected build:
+
+- Header row: "Responsive Score N/5"
+- Row of 4 thumbnail screenshots, labelled with viewport + score
+- Click a thumbnail → lightbox full-size
+- Failure list in plain English (same strings that feed the prompt)
+
+Screenshots are copied to `public/archive/YYYY-MM-DD/screenshots/{viewport}-{buildId}.png`
+by the archive step. /dev references them via normal static path.
+
+### New route `/dev/responsive`
+
+New file `app/routes/dev.responsive.tsx`. Four sections:
+
+1. **Overall score over time** — line chart, last 30 builds, 7-day moving average as a dashed line
+2. **Per-viewport score over time** — 4-line chart (mobile, tablet, laptop, desktop)
+3. **Failure types (last 30 builds)** — horizontal bar chart of check-type frequencies
+4. **Worst by archetype** — table, avg score per archetype, build count
+5. **Worst recent builds** — clickable list; each row links to the rating panel for that build
+
+Charts are hand-rolled inline SVG (zero deps) to match the minimal-dep
+aesthetic of /dev. No visx / recharts.
+
+Data loading via a new server function `readResponsiveHistory()` in
+`app/server/archive-impl.ts`. Scans `archive/*/build-*/responsive-metrics.json`,
+returns the last N builds.
+
+### "Re-score" button
+
+On the rating panel, a button calls `/api/dev-rescore` which runs the
+screenshotter + scorer against the selected build's archived HTML
+(served from public/archive). Used for backfilling historical metrics
+and for re-running after scoring rules change.
+
+## Feedback Loop
+
+New file `scripts/utils/prompt-feedback-selector.js`.
+
+### Selection algorithm
+
+```
+1. Pull last 7 BUILDS with responsive-metrics.json (not 7 calendar days —
+   CI may skip a day, and "builds" is the deterministic unit).
+2. If fewer than 3 builds scored: return null (cold-start guard).
+3. Get today's archetype.
+4. Prefer: a build in the SAME archetype with overallScore ≤ 3
+   AND that has been injected fewer than 2 times
+   (tracked via usedInPromptFor in the metrics JSON).
+5. Otherwise: most recent build in any archetype with overallScore ≤ 3
+   meeting the same reuse cap.
+6. If nothing qualifies: return null.
+7. On select: append today's date to usedInPromptFor in the selected
+   build's responsive-metrics.json (in-place write-back). This mutates
+   a single tracking field in the archive JSON; the design output and
+   scoring fields are never modified.
+```
+
+### Formatted lesson example
+
+```
+Recent lesson (2026-04-13, Specimen archetype, mobile score 1/5):
+
+The hero "DOUG MARCH" was rendered at a fixed 180px font-size, which
+produced horizontal overflow at 360px (scrollWidth 540 > viewport 360).
+The specimen composition was strong — the failure was mechanical scaling.
+
+Today's archetype is Specimen. When using specimen-scale type, wrap
+font-size in clamp() with a mobile floor — e.g.
+font-size: clamp(3rem, 14vw, 11.25rem) keeps the character without
+breaking layout.
+```
+
+### Injection in `scripts/utils/prompt-builder.js`
+
+```js
+const recentLesson = await selectRecentFailure({
+  history: await readResponsiveHistory(),
+  today: new Date(),
+})
+if (recentLesson) {
+  userPrompt += `\n\n## Lesson from Recent Builds\n\n${recentLesson}`
+}
+```
+
+Gated behind `RESPONSIVE_FEEDBACK_LOOP=1` env var so it can be enabled
+in CI independently of local dev.
+
+### Ossification safeguards
+
+1. **Age cap:** only injections from the last 7 days.
+2. **Reuse cap:** each failure injected at most twice.
+3. **Archetype-scoped:** matching-archetype failures preferred; prevents
+   cross-archetype noise.
+4. **Null-safe:** if no qualifying failure exists, inject nothing — the
+   prompt falls back to the static mobile-first guidance from the
+   prompt layer alone.
+
+## Testing Strategy
+
+### Unit tests (fast, no browser)
+
+- `tests/utils/responsive-scorer.test.js` — each check against jsdom
+  fixtures:
+  - `overflow-horizontal.html` → `horizontalScroll: true`
+  - `clipped-hero.html` → `clippedElements.length === 1`
+  - `tiny-body.html` → `bodyTextSize: { min: 12 }`
+  - `small-tap-targets.html` → `tapTargetFailures.length > 0`
+  - `clean.html` → all checks pass
+- `tests/utils/prompt-feedback-selector.test.js` — synthetic history
+  arrays exercising each selection branch (cold-start, matching
+  archetype, fallback, reuse-cap, age-cap, all-null).
+
+### Integration tests (real browser, bumped timeout)
+
+- `tests/scripts/viewport-screenshotter.test.js` — Playwright against a
+  known fixture on a local static server; assert 4 PNGs with expected
+  dimensions. `testTimeout: 30_000`.
+- `tests/scripts/responsive-metrics-pipeline.test.js` — feed synthetic
+  build through screenshotter + scorer + archiver; assert
+  `responsive-metrics.json` shape. `testTimeout: 30_000`.
+
+### E2E tests (Playwright against dev server)
+
+- `tests/e2e/dev-responsive-panel.spec.ts` — rating panel renders card,
+  all 4 screenshots visible, failure list populated.
+- `tests/e2e/dev-responsive-trend.spec.ts` — /dev/responsive renders
+  all 4 chart sections; clickable build rows navigate correctly.
+
+### Mocking rule
+
+Unit tests MUST NOT launch browsers. Per the recent CI fix
+(`archiver-color-scheme.test.js`), browser-launching operations must
+bump `testTimeout` or be mocked. Only the two integration tests named
+above launch real browsers.
+
+## Rollout Plan
+
+Five phases. Each ships independently, each is valuable on its own,
+each is rolled back without touching the others.
+
+| Phase | Scope | Rollback |
+|---|---|---|
+| 1. Measurement | `viewport-screenshotter` + `responsive-scorer` + orchestration in `daily-redesign.js` + extend `archiver.js` to copy screenshots to `public/` | revert commit, delete 2 files |
+| 2. Prompt layer | `unified-designer.md` + 8 seed files | revert prompt files |
+| 3. /dev rating card | `app/dev-panel.tsx` card renders when metrics exist | revert component |
+| 4. Feedback loop | `prompt-feedback-selector.js` + injection in `prompt-builder.js`, gated behind `RESPONSIVE_FEEDBACK_LOOP=1` | flip env var off |
+| 5. Trend dashboard | `app/routes/dev.responsive.tsx` + `readResponsiveHistory()` | delete route file |
+
+### Sequencing reasoning
+
+- Measurement first — the system is worthless without data, and we
+  need the baseline to prove prompt changes worked.
+- Prompt layer second — the change most likely to move the needle.
+- /dev card third — humans can see what's happening before the
+  dashboard is ready.
+- Feedback loop fourth — needs a few days of metrics to pull from
+  without null-returning.
+- Dashboard last — needs history (~10+ builds) to be visually
+  meaningful.
+
+### Gate between phases
+
+- After phase 1: run 3–5 builds, verify metrics written correctly.
+- After phase 2: run 5–7 builds, check scores improve vs baseline.
+- If phase 2 shows no improvement: rethink the prompt layer before
+  adding the feedback loop. Bad prompts don't get fixed by looping
+  them back into themselves.
+
+## Open Questions
+
+None at spec time. All scope decisions locked in brainstorming. If
+implementation surfaces ambiguity, resolve in the implementation plan,
+not here.
+
+## Future Work (out of scope)
+
+- Container queries (`@container`) for components that should respond
+  to their parent, not the viewport. Useful once designs use more
+  nested compositional elements.
+- Fluid typography tokens baked into the chassis — would remove the
+  need for the designer to remember `clamp()`. Deferred until we see
+  whether prompt guidance alone gets us there.
+- Real-device testing (Playwright has device emulation for touch +
+  retina). Current plan only tests viewport widths. Device emulation
+  may catch failures the current approach misses (hover assumptions,
+  touch jitter).
+- Archetype-specific responsive rules in the scorer (e.g., a Specimen
+  build should fail if the specimen element shrinks below 60% of
+  viewport width at mobile). Deferred until general rules mature.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     // Dev-panel tests are local-only — the /dev route is infrastructure, not deployed
     ...(process.env.CI ? [] : [{
       name: 'dev-panel',
-      testMatch: '**/dev-panel.spec.ts',
+      testMatch: ['**/dev-panel.spec.ts', '**/dev-responsive-panel.spec.ts', '**/dev-responsive-trend.spec.ts'],
       use: {
         ...devices['Desktop Chrome'],
         baseURL: DEV_URL,

--- a/scripts/design-agents.js
+++ b/scripts/design-agents.js
@@ -982,7 +982,6 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
     try {
       const { readResponsiveHistory } = await import('./utils/read-responsive-history.js')
       const { selectRecentFailure } = await import('./utils/prompt-feedback-selector.js')
-      const { readFile: readFileDynamic, writeFile: writeFileDynamic } = await import('fs/promises')
       const history = await readResponsiveHistory({ limit: 7 })
       const today = new Date().toISOString().slice(0, 10)
       const { lesson, selectedBuildId } = selectRecentFailure({
@@ -996,15 +995,16 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
           const b = history.find(x => x.buildId === selectedBuildId)
           if (b) {
             const metricsPath = path.join(
+              ROOT,
               'archive',
               b.date,
               `build-${b.buildId}`,
               'responsive-metrics.json'
             )
             try {
-              const raw = JSON.parse(await readFileDynamic(metricsPath, 'utf8'))
+              const raw = JSON.parse(await readFile(metricsPath, 'utf8'))
               raw.usedInPromptFor = [...(raw.usedInPromptFor || []), today]
-              await writeFileDynamic(metricsPath, JSON.stringify(raw, null, 2), 'utf8')
+              await writeFile(metricsPath, JSON.stringify(raw, null, 2), 'utf8')
             } catch { /* non-blocking */ }
           }
         }

--- a/scripts/design-agents.js
+++ b/scripts/design-agents.js
@@ -1240,7 +1240,7 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
     const rationale = tokenResult.rationale || 'Agent swarm redesign'
     const designBrief = tokenResult.design_brief || 'Multi-agent redesign'
 
-    await archive(signals.date, signals, rationale, designBrief, changedPaths, {}, tokenResult.color_scheme ?? null)
+    await archive(signals.date, signals, rationale, designBrief, changedPaths, {}, tokenResult.color_scheme ?? null, chosenArchetype ?? null)
     archiveRan = true
 
     // Save archetype for future anti-repetition enforcement
@@ -1351,7 +1351,7 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
     const rationale = tokenResult.rationale || 'Agent swarm redesign (retry)'
     const designBrief = tokenResult.design_brief || 'Multi-agent redesign (retry)'
 
-    await archive(signals.date, signals, rationale, designBrief, changedPaths, {}, tokenResult.color_scheme ?? null)
+    await archive(signals.date, signals, rationale, designBrief, changedPaths, {}, tokenResult.color_scheme ?? null, chosenArchetype ?? null)
     archiveRan = true
 
     // Save archetype for future anti-repetition enforcement

--- a/scripts/design-agents.js
+++ b/scripts/design-agents.js
@@ -975,6 +975,46 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
     ? `## Visual Specification (from Design Director)\n\n${visualSpec}\n\n---\n\n## Original Creative Brief\n\n${brief}`
     : brief
 
+  // Responsive feedback loop: inject a cautionary lesson from a recent failing build
+  // into the unified designer's prompt. Env-gated; non-blocking on failure.
+  let responsiveLesson = null
+  if (process.env.RESPONSIVE_FEEDBACK_LOOP === '1' && chosenArchetype) {
+    try {
+      const { readResponsiveHistory } = await import('./utils/read-responsive-history.js')
+      const { selectRecentFailure } = await import('./utils/prompt-feedback-selector.js')
+      const { readFile: readFileDynamic, writeFile: writeFileDynamic } = await import('fs/promises')
+      const history = await readResponsiveHistory({ limit: 7 })
+      const today = new Date().toISOString().slice(0, 10)
+      const { lesson, selectedBuildId } = selectRecentFailure({
+        history,
+        todayArchetype: chosenArchetype,
+        today,
+      })
+      if (lesson) {
+        responsiveLesson = lesson
+        if (selectedBuildId) {
+          const b = history.find(x => x.buildId === selectedBuildId)
+          if (b) {
+            const metricsPath = path.join(
+              'archive',
+              b.date,
+              `build-${b.buildId}`,
+              'responsive-metrics.json'
+            )
+            try {
+              const raw = JSON.parse(await readFileDynamic(metricsPath, 'utf8'))
+              raw.usedInPromptFor = [...(raw.usedInPromptFor || []), today]
+              await writeFileDynamic(metricsPath, JSON.stringify(raw, null, 2), 'utf8')
+            } catch { /* non-blocking */ }
+          }
+        }
+        console.log(`  responsive lesson injected from build ${selectedBuildId}`)
+      }
+    } catch (err) {
+      console.warn(`  responsive feedback injection failed (non-blocking): ${err.message}`)
+    }
+  }
+
   // Build the unified-designer user prompt via the shared prompt-builder so
   // production matches local-dev byte-for-byte up to the production-only
   // additions (ratings + creative weights) appended below.
@@ -991,6 +1031,7 @@ export async function runAgentSwarm(context, { onTraceStep } = {}) {
       contentSummary: '',
       currentFiles: [],
       tokenContext,
+      responsiveLesson,
     })
     return messages[0].content
       + (recentRatings ? '\n\n## User Design Ratings (learn from these)\n\nThe site owner rates each design after it ships. Higher scores = what they want to see more of. Notes explain what specifically worked or didn\'t.\n' + recentRatings : '')

--- a/scripts/prompts/seeds/broadsheet.md
+++ b/scripts/prompts/seeds/broadsheet.md
@@ -32,3 +32,7 @@ Dense multi-column grid (3–5 columns). Gutters narrow (16–20px). Generous le
 - DO NOT use drop shadows, rounded cards, or pill buttons
 - DO NOT render a single-column hero — the front page is columnar from first pixel
 - DO NOT use pure #FFFFFF or #000000 — warm paper and ink black only
+
+## Mobile strategy
+
+Masthead stacks vertically on mobile: logo → name (Playfair, smaller) → nav as a pill row → date. Columns collapse to a single column with section dividers styled like masthead rules (full-width horizontal lines, not gutters). Datelines and kickers stay visible; they define the archetype.

--- a/scripts/prompts/seeds/gallery-wall.md
+++ b/scripts/prompts/seeds/gallery-wall.md
@@ -33,3 +33,7 @@ Masonry columns (3–5 depending on viewport). Column gap tight (12–16px). Row
 - DO NOT use the red accent as a large fill — it marks interactions only
 - DO NOT render fewer than 6 tiles on the first viewport — density is the voice
 - DO NOT use serif type
+
+## Mobile strategy
+
+Wall becomes a vertical scroll of framed artifacts on mobile. Each artifact keeps its scale *relative* to viewport width (e.g. 80vw for featured pieces, 60vw for thumbnails) rather than absolute pixels. The curator's logic should still read — don't just list items end to end; keep the varied rhythm.

--- a/scripts/prompts/seeds/index.md
+++ b/scripts/prompts/seeds/index.md
@@ -33,3 +33,7 @@ Tight vertical rhythm — rows are 32–40px tall. Horizontal columns aligned to
 - DO NOT vary row heights — uniform rhythm is the voice
 - DO NOT use serif type
 - DO NOT apply the purple accent as a background fill — it marks, never coats
+
+## Mobile strategy
+
+Table rows collapse to stacked cards at ≤ 768px. Year / role / description become inline labels within each card, not adjacent columns. The overall "index" character is preserved by keeping consistent row rhythm and visible row numbers or bullets.

--- a/scripts/prompts/seeds/poster.md
+++ b/scripts/prompts/seeds/poster.md
@@ -31,3 +31,7 @@ Whitespace is the design. Sections are full-viewport height; content is centered
 - DO NOT use card grids, drop shadows, or rounded-corner containers
 - DO NOT fill the page with body copy — captions only, set small
 - DO NOT use more than two type sizes on the hero viewport
+
+## Mobile strategy
+
+Retains single dominant element on mobile — scale the hero via `clamp()`. Secondary info (nav, metadata, footer) stays anchored to the poster's bottom, not fighting the hero. If the hero needs to reflow (e.g. "DOUG / MARCH" instead of "DOUG MARCH"), the reflow should look intentional, not cramped.

--- a/scripts/prompts/seeds/scroll.md
+++ b/scripts/prompts/seeds/scroll.md
@@ -33,3 +33,7 @@ Sections are 100vh or taller. Internal padding is generous: 80–160px vertical,
 - DO NOT pack a viewport with more than one headline + one image + one caption
 - DO NOT use harsh borders or drop shadows
 - DO NOT use saturated color fills — palette stays near-monochrome with rare blue accent
+
+## Mobile strategy
+
+Already fluid by nature. Ensure signal marginalia (weather, scores, quotes) collapses to **inline** captions or small-caps labels, not floating pull-quotes. Don't place marginalia in the margin at 360px — there is no margin. Tuck them between content beats instead.

--- a/scripts/prompts/seeds/specimen.md
+++ b/scripts/prompts/seeds/specimen.md
@@ -32,3 +32,7 @@ Spacing scale on a 4px grid (4, 8, 16, 24, 48, 96). Hero sections are type-only 
 - DO NOT use drop shadows or heavy borders
 - DO NOT center body copy
 - DO NOT render photography-first sections — type dominates every viewport
+
+## Mobile strategy
+
+Specimen fills the full viewport width on mobile; the label block (metadata, callouts, signals) stacks **below** the specimen, not beside. Hero type uses `font-size: clamp(3rem, 14vw, 11.25rem)` so the specimen-scale character survives shrinking without overflow. The specimen element itself should be ≥ 60% of viewport height on mobile — don't let it collapse into something indistinguishable from normal body content.

--- a/scripts/prompts/seeds/split.md
+++ b/scripts/prompts/seeds/split.md
@@ -32,3 +32,7 @@ Two halves in tension. One side is bold, saturated, gradient-lit — the other i
 - DO NOT use the gradient on both sides — it belongs only on the bold pane
 - DO NOT stack the panes vertically on desktop — horizontal split is the identity
 - DO NOT use identical card treatments across both panes
+
+## Mobile strategy
+
+Two halves become two stacked sections on mobile. The divider becomes a horizontal rule (or negative space between sections). Asymmetry carries via aspect-ratio difference — the dominant half gets more vertical space. Avoid flipping which half dominates between viewports.

--- a/scripts/prompts/seeds/stack.md
+++ b/scripts/prompts/seeds/stack.md
@@ -34,3 +34,7 @@ Vertical bands separated by 80–120px of padding. Each band has its own interna
 - DO NOT use sharp square corners — rounded is the voice
 - DO NOT use saturated gradients or neon accents
 - DO NOT skip band padding — bands need breathing room to feel distinct
+
+## Mobile strategy
+
+Already naturally mobile-friendly. Use `min-height` tokens that scale down — no `height: 100vh` without a mobile fallback like `min-height: 500px`. Bands should stack with clear visual breaks at all widths.

--- a/scripts/prompts/unified-designer.md
+++ b/scripts/prompts/unified-designer.md
@@ -153,6 +153,22 @@ These constraints cannot be relaxed for creative direction. Bold design and acce
 - All nav links keyboard-accessible
 - All links visually distinguishable from surrounding text (color, underline, or other treatment)
 
+## Responsive — Mobile-First, Not Desktop-Squashed
+
+You are designing for three characters: phone (360px), tablet (768px), laptop/desktop (1024px / 1440px). Start your composition at 360px and enhance upward. A design that looks great on desktop but overflows or clips on mobile is a failed build regardless of how striking the desktop view is.
+
+**Mobile-first means:**
+- Default CSS targets 360px. Use `@media (min-width: ...)` to add complexity at larger widths — never subtract at smaller.
+- Large type uses `clamp()` or `vw` with caps, not fixed px. A specimen-scale hero at 120px on desktop should collapse to ~48px on mobile.
+- Fixed sidebars, multi-column grids, and persistent nav rails must have a collapse strategy below the tablet breakpoint (usually stacking into a single column).
+- Header chrome (logo + nav + signals) must not overlap at 360px. If everything can't fit, stack or hide behind a toggle.
+- Touch targets ≥ 44×44px on any viewport ≤ 768px.
+- Body text ≥ 16px at all viewports.
+- Line length ≤ 75 characters at all viewports.
+
+**What gets checked automatically:**
+Every build runs at 360 / 768 / 1024 / 1440 and is scored on: horizontal scroll, content clipping, header overlap, body text size, tap-target size, line length. Failures are logged and fed back into tomorrow's prompt as negative examples.
+
 ## Required Files
 
 You MUST produce these files. Organize the code however you want — inline in routes, extract components, or mix. Only the framework constraints below are hard requirements.

--- a/scripts/test-redesign-manual.js
+++ b/scripts/test-redesign-manual.js
@@ -151,7 +151,7 @@ async function main() {
 
     // Archive
     const changedPaths = files.map((f) => f.path)
-    await archive(context.signals.date, context.signals, rationale, design_brief, changedPaths)
+    await archive(context.signals.date, context.signals, rationale, design_brief, changedPaths, {}, null, null)
 
     console.log('\nDRY RUN — restoring originals (not committing).')
     await restore(originalBackup)

--- a/scripts/utils/archiver.js
+++ b/scripts/utils/archiver.js
@@ -132,8 +132,9 @@ function formatSignalsMarkdown(signals) {
  * @param {string[]} changedFiles - list of relative file paths that were written
  * @param {object} [weights={}] - optional weighting overrides (signals, inspiration, ratings, risk)
  * @param {object|null} [colorScheme=null] - optional color scheme object emitted by the designer; written as color-scheme.json in the build dir
+ * @param {string|null} [archetype=null] - the chosen archetype for this build (e.g. 'Specimen')
  */
-export async function archive(date, signals, rationale, designBrief, changedFiles, weights = {}, colorScheme = null) {
+export async function archive(date, signals, rationale, designBrief, changedFiles, weights = {}, colorScheme = null, archetype = null) {
   const dateStr = date instanceof Date ? date.toISOString().slice(0, 10) : String(date)
   const buildId = String(Date.now())
   const dir = path.join(ROOT, 'archive', dateStr)
@@ -286,7 +287,7 @@ export async function archive(date, signals, rationale, designBrief, changedFile
         const metrics = await scoreResponsive(previewUrl, viewports, { browser })
         metrics.buildId = buildId
         metrics.date = dateStr
-        metrics.archetype = null
+        metrics.archetype = archetype
         metrics.usedInPromptFor = []
 
         await writeFile(

--- a/scripts/utils/archiver.js
+++ b/scripts/utils/archiver.js
@@ -238,6 +238,59 @@ export async function archive(date, signals, rationale, designBrief, changedFile
     console.warn(`  screenshot failed (non-blocking): ${err.message}`)
   }
 
+  // Responsive measurement — soft-fail, non-blocking.
+  // Only runs when the dev server is up (the only way we can point a
+  // headless browser at the built site).
+  try {
+    const net = await import('net')
+    const portOpen = await new Promise(resolve => {
+      const sock = new net.Socket()
+      sock.setTimeout(2000)
+      sock.once('connect', () => { sock.destroy(); resolve(true) })
+      sock.once('error', () => resolve(false))
+      sock.once('timeout', () => { sock.destroy(); resolve(false) })
+      sock.connect(5173, '127.0.0.1')
+    })
+    if (portOpen) {
+      const previewUrl = 'http://localhost:5173/'
+      const viewports = [
+        { name: 'mobile',  width: 360,  height: 640 },
+        { name: 'tablet',  width: 768,  height: 1024 },
+        { name: 'laptop',  width: 1024, height: 768 },
+        { name: 'desktop', width: 1440, height: 900 },
+      ]
+      const { chromium } = await import('@playwright/test')
+      const { screenshotViewports } = await import('./viewport-screenshotter.js')
+      const { scoreResponsive } = await import('./responsive-scorer.js')
+
+      const browser = await chromium.launch({ headless: true })
+      try {
+        const vpDir = path.join(buildDir, 'viewports')
+        await mkdir(vpDir, { recursive: true })
+        await screenshotViewports(previewUrl, viewports, vpDir, { browser })
+
+        const metrics = await scoreResponsive(previewUrl, viewports, { browser })
+        metrics.buildId = buildId
+        metrics.date = dateStr
+        metrics.archetype = null
+        metrics.usedInPromptFor = []
+
+        await writeFile(
+          path.join(buildDir, 'responsive-metrics.json'),
+          JSON.stringify(metrics, null, 2),
+          'utf8'
+        )
+        console.log(`  responsive metrics written (overall ${metrics.overallScore}/5)`)
+      } finally {
+        await browser.close()
+      }
+    } else {
+      console.log(`  dev server not running, skipping responsive measurement`)
+    }
+  } catch (err) {
+    console.warn(`  responsive scoring failed (non-blocking): ${err.message}`)
+  }
+
   // Copy artifacts to public/ for static serving
   try {
     await copyToPublic(dateStr, buildDir)

--- a/scripts/utils/archiver.js
+++ b/scripts/utils/archiver.js
@@ -40,6 +40,20 @@ async function copyToPublic(dateStr, buildDir) {
     }
     console.log(`  copied site HTML to public/archive/${dateStr}/`)
   }
+
+  // Copy viewport screenshots (if the build produced them)
+  const vpSrc = path.join(buildDir, 'viewports')
+  if (existsSync(vpSrc)) {
+    const vpDest = path.join(publicBase, dateStr, 'viewports')
+    await mkdir(vpDest, { recursive: true })
+    const vpEntries = await readdir(vpSrc)
+    for (const f of vpEntries) {
+      if (f.endsWith('.png')) {
+        await copyFile(path.join(vpSrc, f), path.join(vpDest, f))
+      }
+    }
+    console.log(`  copied viewport screenshots to public/archive/${dateStr}/viewports/`)
+  }
 }
 
 /**

--- a/scripts/utils/prompt-builder.js
+++ b/scripts/utils/prompt-builder.js
@@ -175,12 +175,20 @@ ${file.content}
     }
   }
 
+  // Optional: Cautionary lesson from a recent failing build.
+  // Set by the orchestrator when RESPONSIVE_FEEDBACK_LOOP=1 is active.
+  if (context.responsiveLesson && context.responsiveLesson.trim()) {
+    sections.push(`## Lesson from Recent Builds
+
+${context.responsiveLesson}`)
+  }
+
   return sections.join('\n\n')
 }
 
 /**
  * Build the messages array for the Claude API call.
- * @param {{ signals: object, contentSummary: string, currentFiles: Array<{path: string, content: string}>, brief?: string, tokenContext?: string|null }} context
+ * @param {{ signals: object, contentSummary: string, currentFiles: Array<{path: string, content: string}>, brief?: string, tokenContext?: string|null, responsiveLesson?: string|null }} context
  * @returns {{ system: string, messages: Array<{role: string, content: string}> }}
  */
 export function buildMessages(context) {

--- a/scripts/utils/prompt-feedback-selector.js
+++ b/scripts/utils/prompt-feedback-selector.js
@@ -1,0 +1,40 @@
+/**
+ * Format a cautionary lesson from a chosen build's worstFailure.
+ */
+function formatLesson(b) {
+  const f = b.worstFailure
+  return [
+    `Recent lesson (${b.date}, ${b.archetype || 'unknown'} archetype, ${f.viewport} score ${b.viewports?.[f.viewport]?.score ?? '?'}/5):`,
+    '',
+    `The ${f.check} check failed: ${f.detail}.`,
+    '',
+    'Apply the mobile-first rules above to avoid repeating this pattern.',
+  ].join('\n')
+}
+
+/**
+ * Pick a recent failing build to inject as a lesson in today's prompt.
+ *
+ * @param {object} opts
+ * @param {Array<object>} opts.history - recent builds, newest-first (expected from readResponsiveHistory)
+ * @param {string} opts.todayArchetype
+ * @param {string} opts.today - ISO date of today's build
+ * @returns {{ lesson: string|null, selectedBuildId: string|null }}
+ */
+export function selectRecentFailure({ history, todayArchetype, today }) {
+  const recent = history.slice(0, 7)
+  if (recent.length < 3) return { lesson: null, selectedBuildId: null }
+
+  const eligible = recent.filter(b =>
+    typeof b.overallScore === 'number' && b.overallScore <= 3 &&
+    (Array.isArray(b.usedInPromptFor) ? b.usedInPromptFor.length < 2 : true) &&
+    b.worstFailure
+  )
+  if (eligible.length === 0) return { lesson: null, selectedBuildId: null }
+
+  // Prefer matching archetype
+  const matching = eligible.find(b => b.archetype === todayArchetype)
+  const chosen = matching || eligible[0]
+
+  return { lesson: formatLesson(chosen), selectedBuildId: chosen.buildId }
+}

--- a/scripts/utils/read-responsive-history.js
+++ b/scripts/utils/read-responsive-history.js
@@ -1,0 +1,41 @@
+import { readdir, readFile } from 'fs/promises'
+import path from 'path'
+
+/**
+ * Read recent responsive-metrics.json files across archive dirs.
+ * Returned newest-first, limited to `limit` builds.
+ *
+ * @param {object} opts
+ * @param {string} opts.root - project root (defaults to cwd)
+ * @param {number} [opts.limit=30]
+ * @returns {Promise<Array<object>>}
+ */
+export async function readResponsiveHistory({ root = process.cwd(), limit = 30 } = {}) {
+  const archiveRoot = path.join(root, 'archive')
+  let dates
+  try {
+    dates = (await readdir(archiveRoot)).filter(d => /^\d{4}-\d{2}-\d{2}$/.test(d))
+  } catch {
+    return []
+  }
+  dates.sort().reverse()
+
+  const out = []
+  for (const date of dates) {
+    const dateDir = path.join(archiveRoot, date)
+    let builds
+    try {
+      builds = (await readdir(dateDir)).filter(b => b.startsWith('build-'))
+    } catch { continue }
+    builds.sort().reverse()
+    for (const b of builds) {
+      const p = path.join(dateDir, b, 'responsive-metrics.json')
+      try {
+        const raw = await readFile(p, 'utf8')
+        out.push(JSON.parse(raw))
+      } catch { /* missing or invalid — skip */ }
+      if (out.length >= limit) return out
+    }
+  }
+  return out
+}

--- a/scripts/utils/responsive-scorer.js
+++ b/scripts/utils/responsive-scorer.js
@@ -1,0 +1,49 @@
+import { chromium } from '@playwright/test'
+
+const CHECKS = {
+  horizontalScroll: () =>
+    document.documentElement.scrollWidth > window.innerWidth,
+}
+
+/**
+ * Score a URL across viewports.
+ * Each check runs in the page context after setting viewport.
+ *
+ * @param {string} url
+ * @param {Array<{name, width, height}>} viewports
+ * @param {object} [opts]
+ * @param {import('@playwright/test').Browser} [opts.browser] - optional
+ *   externally-managed browser (tests reuse one; production launches its own)
+ * @returns {Promise<object>} metrics
+ */
+export async function scoreResponsive(url, viewports, opts = {}) {
+  const ownBrowser = !opts.browser
+  const browser = opts.browser || (await chromium.launch({ headless: true }))
+
+  try {
+    const page = await browser.newPage()
+    const viewportResults = {}
+
+    for (const vp of viewports) {
+      await page.setViewportSize({ width: vp.width, height: vp.height })
+      await page.goto(url, { waitUntil: 'networkidle' })
+      await page.waitForTimeout(300)
+
+      const checks = {}
+      for (const [name, fn] of Object.entries(CHECKS)) {
+        checks[name] = await page.evaluate(fn)
+      }
+
+      viewportResults[vp.name] = {
+        width: vp.width,
+        height: vp.height,
+        checks,
+      }
+    }
+
+    await page.close()
+    return { viewports: viewportResults }
+  } finally {
+    if (ownBrowser) await browser.close()
+  }
+}

--- a/scripts/utils/responsive-scorer.js
+++ b/scripts/utils/responsive-scorer.js
@@ -3,6 +3,22 @@ import { chromium } from '@playwright/test'
 const CHECKS = {
   horizontalScroll: () =>
     document.documentElement.scrollWidth > window.innerWidth,
+  clippedElements: () => {
+    const vw = window.innerWidth
+    const out = []
+    for (const el of document.querySelectorAll('body *')) {
+      const r = el.getBoundingClientRect()
+      if (r.width === 0 || r.height === 0) continue
+      if (r.right > vw + 1) {
+        out.push({
+          tag: el.tagName,
+          text: (el.textContent || '').trim().slice(0, 50),
+          right: Math.round(r.right),
+        })
+      }
+    }
+    return out
+  },
 }
 
 /**

--- a/scripts/utils/responsive-scorer.js
+++ b/scripts/utils/responsive-scorer.js
@@ -39,6 +39,22 @@ const CHECKS = {
     }
     return overlaps
   },
+  bodyTextSize: () => {
+    const root = document.querySelector('main') || document.body
+    let min = Infinity
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    let n
+    while ((n = walker.nextNode())) {
+      const text = (n.textContent || '').trim()
+      if (text.length < 8) continue
+      const parent = n.parentElement
+      if (!parent) continue
+      const fs = parseFloat(getComputedStyle(parent).fontSize)
+      if (fs && fs < min) min = fs
+    }
+    if (min === Infinity) return { min: null, passing: true }
+    return { min: Math.round(min * 10) / 10, passing: min >= 16 }
+  },
 }
 
 /**

--- a/scripts/utils/responsive-scorer.js
+++ b/scripts/utils/responsive-scorer.js
@@ -99,6 +99,60 @@ const CHECKS = {
 }
 
 /**
+ * Count failures for a viewport's checks.
+ */
+function countFailures(checks) {
+  let n = 0
+  if (checks.horizontalScroll) n++
+  if (Array.isArray(checks.clippedElements) && checks.clippedElements.length) n++
+  if (Array.isArray(checks.headerOverlap) && checks.headerOverlap.length) n++
+  if (checks.bodyTextSize && checks.bodyTextSize.passing === false) n++
+  if (Array.isArray(checks.tapTargetFailures) && checks.tapTargetFailures.length) n++
+  if (Array.isArray(checks.lineLengthFailures) && checks.lineLengthFailures.length) n++
+  return n
+}
+
+/** failure count → 1..5 (inverted, capped at 4+ failures = 1) */
+function scoreFromFailureCount(n) {
+  if (n === 0) return 5
+  if (n === 1) return 4
+  if (n === 2) return 3
+  if (n === 3) return 2
+  return 1
+}
+
+/** Pick the first failing check type (for worstFailure reporting) */
+function firstFailingCheck(checks) {
+  if (checks.horizontalScroll) return 'horizontalScroll'
+  if (checks.clippedElements?.length) return 'clippedElements'
+  if (checks.headerOverlap?.length) return 'headerOverlap'
+  if (checks.bodyTextSize?.passing === false) return 'bodyTextSize'
+  if (checks.tapTargetFailures?.length) return 'tapTargetFailures'
+  if (checks.lineLengthFailures?.length) return 'lineLengthFailures'
+  return null
+}
+
+function formatFailureDetail(check, viewportResult) {
+  const c = viewportResult.checks
+  switch (check) {
+    case 'horizontalScroll':
+      return `document.scrollWidth exceeded viewport ${viewportResult.width}px`
+    case 'clippedElements':
+      return `${c.clippedElements.length} element(s) extended past the viewport (first: <${c.clippedElements[0].tag}>)`
+    case 'headerOverlap':
+      return `${c.headerOverlap.length} overlapping pair(s) in the header`
+    case 'bodyTextSize':
+      return `body text min ${c.bodyTextSize.min}px (floor 16px)`
+    case 'tapTargetFailures':
+      return `${c.tapTargetFailures.length} interactive element(s) below 44×44px`
+    case 'lineLengthFailures':
+      return `${c.lineLengthFailures.length} paragraph(s) over 75 chars per line`
+    default:
+      return 'unknown'
+  }
+}
+
+/**
  * Score a URL across viewports.
  * Each check runs in the page context after setting viewport.
  *
@@ -139,11 +193,31 @@ export async function scoreResponsive(url, viewports, opts = {}) {
         width: vp.width,
         height: vp.height,
         checks,
+        score: scoreFromFailureCount(countFailures(checks)),
+      }
+    }
+
+    const overallScore = Math.min(
+      ...Object.values(viewportResults).map(v => v.score)
+    )
+
+    let worstFailure = null
+    const worstVp = Object.entries(viewportResults)
+      .sort(([, a], [, b]) => a.score - b.score)[0]
+    if (worstVp && worstVp[1].score < 5) {
+      const [vpName, vpResult] = worstVp
+      const check = firstFailingCheck(vpResult.checks)
+      if (check) {
+        worstFailure = {
+          viewport: vpName,
+          check,
+          detail: formatFailureDetail(check, vpResult),
+        }
       }
     }
 
     await page.close()
-    return { viewports: viewportResults }
+    return { viewports: viewportResults, overallScore, worstFailure }
   } finally {
     if (ownBrowser) await browser.close()
   }

--- a/scripts/utils/responsive-scorer.js
+++ b/scripts/utils/responsive-scorer.js
@@ -173,7 +173,7 @@ export async function scoreResponsive(url, viewports, opts = {}) {
 
     for (const vp of viewports) {
       await page.setViewportSize({ width: vp.width, height: vp.height })
-      await page.goto(url, { waitUntil: 'networkidle' })
+      await page.goto(url, { waitUntil: 'load', timeout: 30000 })
       await page.waitForTimeout(300)
 
       const checks = {}

--- a/scripts/utils/responsive-scorer.js
+++ b/scripts/utils/responsive-scorer.js
@@ -55,6 +55,24 @@ const CHECKS = {
     if (min === Infinity) return { min: null, passing: true }
     return { min: Math.round(min * 10) / 10, passing: min >= 16 }
   },
+  tapTargetFailures: (viewportWidth) => {
+    if (viewportWidth > 768) return []
+    const selectors = 'a[href], button, [role="button"], input[type="button"], input[type="submit"]'
+    const out = []
+    for (const el of document.querySelectorAll(selectors)) {
+      const r = el.getBoundingClientRect()
+      if (r.width === 0 || r.height === 0) continue
+      if (r.width < 44 || r.height < 44) {
+        out.push({
+          tag: el.tagName,
+          text: (el.textContent || '').trim().slice(0, 30),
+          w: Math.round(r.width),
+          h: Math.round(r.height),
+        })
+      }
+    }
+    return out
+  },
 }
 
 /**
@@ -83,7 +101,15 @@ export async function scoreResponsive(url, viewports, opts = {}) {
 
       const checks = {}
       for (const [name, fn] of Object.entries(CHECKS)) {
-        checks[name] = await page.evaluate(fn)
+        // Pass viewport width as second arg — most checks ignore it.
+        checks[name] = await page.evaluate(
+          ([fnStr, vw]) => {
+            // eslint-disable-next-line no-new-func
+            const f = new Function('return ' + fnStr)()
+            return f(vw)
+          },
+          [fn.toString(), vp.width]
+        )
       }
 
       viewportResults[vp.name] = {

--- a/scripts/utils/responsive-scorer.js
+++ b/scripts/utils/responsive-scorer.js
@@ -19,6 +19,26 @@ const CHECKS = {
     }
     return out
   },
+  headerOverlap: () => {
+    const header = document.querySelector('header') || document.querySelector('nav')
+    if (!header) return []
+    const kids = [...header.children].map(el => ({ el, r: el.getBoundingClientRect() }))
+    const overlaps = []
+    for (let i = 0; i < kids.length; i++) {
+      for (let j = i + 1; j < kids.length; j++) {
+        const a = kids[i].r, b = kids[j].r
+        const xOverlap = !(a.right <= b.left || b.right <= a.left)
+        const yOverlap = !(a.bottom <= b.top || b.bottom <= a.top)
+        if (xOverlap && yOverlap) {
+          overlaps.push({
+            a: kids[i].el.tagName + (kids[i].el.className ? '.' + kids[i].el.className : ''),
+            b: kids[j].el.tagName + (kids[j].el.className ? '.' + kids[j].el.className : ''),
+          })
+        }
+      }
+    }
+    return overlaps
+  },
 }
 
 /**

--- a/scripts/utils/responsive-scorer.js
+++ b/scripts/utils/responsive-scorer.js
@@ -73,6 +73,29 @@ const CHECKS = {
     }
     return out
   },
+  lineLengthFailures: () => {
+    // Approximate: chars per paragraph / rendered line count.
+    // Rendered lines ≈ clientHeight / computed line-height.
+    const out = []
+    for (const p of document.querySelectorAll('p')) {
+      const text = (p.textContent || '').trim()
+      if (text.length < 100) continue
+      const cs = getComputedStyle(p)
+      const lh = parseFloat(cs.lineHeight) ||
+                 (parseFloat(cs.fontSize) * 1.5)
+      const lines = Math.max(1, Math.round(p.clientHeight / lh))
+      const avgChars = text.length / lines
+      if (avgChars > 75) {
+        out.push({
+          chars: text.length,
+          lines,
+          avgPerLine: Math.round(avgChars),
+          excerpt: text.slice(0, 40),
+        })
+      }
+    }
+    return out
+  },
 }
 
 /**

--- a/scripts/utils/viewport-screenshotter.js
+++ b/scripts/utils/viewport-screenshotter.js
@@ -21,7 +21,7 @@ export async function screenshotViewports(url, viewports, outDir, opts = {}) {
     const results = []
     for (const vp of viewports) {
       await page.setViewportSize({ width: vp.width, height: vp.height })
-      await page.goto(url, { waitUntil: 'networkidle' })
+      await page.goto(url, { waitUntil: 'load', timeout: 30000 })
       await page.waitForTimeout(500)
       const outPath = path.join(outDir, `${vp.name}.png`)
       await page.screenshot({ path: outPath, type: 'png', fullPage: false })

--- a/scripts/utils/viewport-screenshotter.js
+++ b/scripts/utils/viewport-screenshotter.js
@@ -1,0 +1,35 @@
+import { chromium } from '@playwright/test'
+import path from 'path'
+
+/**
+ * Screenshot a URL at multiple viewports.
+ * Single browser, one page, resize between viewports.
+ *
+ * @param {string} url
+ * @param {Array<{name: string, width: number, height: number}>} viewports
+ * @param {string} outDir - absolute path; must exist
+ * @param {object} [opts]
+ * @param {import('@playwright/test').Browser} [opts.browser]
+ * @returns {Promise<Array<{name, width, height, path}>>}
+ */
+export async function screenshotViewports(url, viewports, outDir, opts = {}) {
+  const ownBrowser = !opts.browser
+  const browser = opts.browser || (await chromium.launch({ headless: true }))
+
+  try {
+    const page = await browser.newPage()
+    const results = []
+    for (const vp of viewports) {
+      await page.setViewportSize({ width: vp.width, height: vp.height })
+      await page.goto(url, { waitUntil: 'networkidle' })
+      await page.waitForTimeout(500)
+      const outPath = path.join(outDir, `${vp.name}.png`)
+      await page.screenshot({ path: outPath, type: 'png', fullPage: false })
+      results.push({ name: vp.name, width: vp.width, height: vp.height, path: outPath })
+    }
+    await page.close()
+    return results
+  } finally {
+    if (ownBrowser) await browser.close()
+  }
+}

--- a/tests/e2e/dev-responsive-panel.spec.ts
+++ b/tests/e2e/dev-responsive-panel.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+// Precondition: at least one build in archive/ must have responsive-metrics.json.
+// If none exists, skip — the card only appears inside SuccessSection after a real pipeline run.
+function hasAnyResponsiveMetrics(): boolean {
+  const archive = path.resolve(process.cwd(), 'archive')
+  if (!fs.existsSync(archive)) return false
+  for (const date of fs.readdirSync(archive)) {
+    const dateDir = path.join(archive, date)
+    if (!fs.statSync(dateDir).isDirectory()) continue
+    for (const b of fs.readdirSync(dateDir)) {
+      const p = path.join(dateDir, b, 'responsive-metrics.json')
+      if (fs.existsSync(p)) return true
+    }
+  }
+  return false
+}
+
+test.skip(!hasAnyResponsiveMetrics(), 'no responsive-metrics.json in archive yet')
+
+test('responsive card renders when metrics exist', async ({ page }) => {
+  await page.goto('/dev')
+  // SuccessSection is only visible after a successful pipeline run — this
+  // test documents the assertion shape. If reaching SuccessSection requires
+  // further test setup, this test will timeout, which is also acceptable
+  // evidence that the precondition isn't met.
+  const card = page.getByText('Responsive Score').first()
+  await expect(card).toBeVisible({ timeout: 5000 })
+  const thumbs = page.locator('img[src*="/viewports/"]')
+  await expect(thumbs).toHaveCount(4)
+})

--- a/tests/e2e/dev-responsive-trend.spec.ts
+++ b/tests/e2e/dev-responsive-trend.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test'
+
+// Section labels rendered by ResponsiveTrend unconditionally (outside LineChart,
+// which returns early with "no data" when history is empty — so "Overall score"
+// is NOT reliably visible with an empty archive).
+test('/dev/responsive renders all sections', async ({ page }) => {
+  await page.goto('/dev/responsive')
+  await page.waitForLoadState('networkidle')
+  // Page heading — always rendered
+  await expect(page.getByText('Responsive — last 30 builds').first()).toBeVisible({ timeout: 10000 })
+  // Section labels outside LineChart — always rendered regardless of archive state
+  await expect(page.getByText('Failure types').first()).toBeVisible({ timeout: 10000 })
+  await expect(page.getByText('Worst by archetype').first()).toBeVisible({ timeout: 10000 })
+  await expect(page.getByText('Worst recent builds').first()).toBeVisible({ timeout: 10000 })
+})

--- a/tests/fixtures/responsive/clean.html
+++ b/tests/fixtures/responsive/clean.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: sans-serif; font-size: 16px; line-height: 1.5; }
+    header { display: flex; gap: 16px; padding: 16px; }
+    header > * { flex: 0 0 auto; }
+    a, button { display: inline-block; min-width: 44px; min-height: 44px; padding: 12px; }
+    main { padding: 16px; max-width: 65ch; margin: 0 auto; }
+    h1 { font-size: clamp(2rem, 6vw, 4rem); margin: 0 0 16px; }
+    p { margin: 0 0 16px; }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="/">Logo</a>
+    <nav><a href="/about">About</a></nav>
+  </header>
+  <main>
+    <h1>Clean Page</h1>
+    <p>This page should pass every responsive check at every viewport.</p>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/responsive/clipped-hero.html
+++ b/tests/fixtures/responsive/clipped-hero.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { margin: 0; padding: 0; overflow: hidden; }
+    body { font-family: sans-serif; }
+    .hero { position: absolute; left: 50px; width: 800px; background: red; padding: 20px; color: white; }
+  </style>
+</head>
+<body>
+  <div class="hero">This hero is 800px wide starting at 50px — clipped beyond 360px.</div>
+</body>
+</html>

--- a/tests/fixtures/responsive/header-overlap.html
+++ b/tests/fixtures/responsive/header-overlap.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { margin: 0; padding: 0; }
+    header { position: relative; }
+    header > * {
+      position: absolute; top: 0;
+      padding: 12px; background: rgba(255,0,0,0.3);
+    }
+    .logo { left: 0; width: 200px; }
+    .nav   { left: 100px; width: 200px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="logo">Logo</div>
+    <div class="nav">Nav</div>
+  </header>
+</body>
+</html>

--- a/tests/fixtures/responsive/long-lines.html
+++ b/tests/fixtures/responsive/long-lines.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style>body{font-family:monospace;font-size:12px;margin:0;padding:16px;max-width:none}p{margin:0}</style></head>
+<body>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua, ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+</body>
+</html>

--- a/tests/fixtures/responsive/overflow-horizontal.html
+++ b/tests/fixtures/responsive/overflow-horizontal.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body { margin: 0; padding: 0; }
+    body { font-family: sans-serif; }
+    h1 { font-size: 180px; white-space: nowrap; margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>DOUG MARCH</h1>
+</body>
+</html>

--- a/tests/fixtures/responsive/small-tap-targets.html
+++ b/tests/fixtures/responsive/small-tap-targets.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style>body{font-family:sans-serif;margin:16px} a,button{padding:2px;font-size:10px;display:inline-block}</style></head>
+<body>
+  <nav><a href="/about">About</a> <button>Menu</button></nav>
+</body>
+</html>

--- a/tests/fixtures/responsive/tiny-body.html
+++ b/tests/fixtures/responsive/tiny-body.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<style>body { font-family: sans-serif; font-size: 12px; margin: 16px; }</style></head>
+<body><main><p>This body text is 12 pixels — below the 16px floor.</p></main></body>
+</html>

--- a/tests/prompt-builder.test.js
+++ b/tests/prompt-builder.test.js
@@ -51,4 +51,16 @@ describe('prompt-builder', () => {
     expect(withoutOptional.messages[0].content).toBe(withUndefined.messages[0].content)
     expect(withoutOptional.messages[0].content).not.toContain('## Design Tokens')
   })
+
+  it('appends the Lesson from Recent Builds section when context.responsiveLesson is present', () => {
+    const lesson = 'Recent lesson (2026-04-14): horizontalScroll failed on mobile.'
+    const { messages } = buildMessages({ ...CONTEXT, responsiveLesson: lesson })
+    expect(messages[0].content).toContain('## Lesson from Recent Builds')
+    expect(messages[0].content).toContain(lesson)
+  })
+
+  it('omits the Lesson section when responsiveLesson is absent', () => {
+    const { messages } = buildMessages(CONTEXT)
+    expect(messages[0].content).not.toContain('## Lesson from Recent Builds')
+  })
 })

--- a/tests/scripts/viewport-screenshotter.test.js
+++ b/tests/scripts/viewport-screenshotter.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtemp, rm, stat } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { screenshotViewports } from '../../scripts/utils/viewport-screenshotter.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const CLEAN = `file://${path.join(__dirname, '../fixtures/responsive/clean.html')}`
+
+describe('viewport-screenshotter', () => {
+  let outDir
+  beforeAll(async () => {
+    outDir = await mkdtemp(path.join(tmpdir(), 'vpscreen-'))
+  })
+  afterAll(async () => {
+    await rm(outDir, { recursive: true, force: true })
+  })
+
+  it('writes one PNG per viewport', async () => {
+    const viewports = [
+      { name: 'mobile', width: 360, height: 640 },
+      { name: 'tablet', width: 768, height: 1024 },
+    ]
+    const results = await screenshotViewports(CLEAN, viewports, outDir)
+    expect(results.length).toBe(2)
+    for (const r of results) {
+      const s = await stat(r.path)
+      expect(s.size).toBeGreaterThan(500)
+      expect(r.path.endsWith(`${r.name}.png`)).toBe(true)
+    }
+  }, 30_000)
+})

--- a/tests/utils/prompt-feedback-selector.test.js
+++ b/tests/utils/prompt-feedback-selector.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { selectRecentFailure } from '../../scripts/utils/prompt-feedback-selector.js'
+
+function build(overrides) {
+  return {
+    buildId: 'b',
+    date: '2026-04-10',
+    archetype: 'Specimen',
+    overallScore: 2,
+    worstFailure: { viewport: 'mobile', check: 'horizontalScroll', detail: 'x' },
+    usedInPromptFor: [],
+    ...overrides,
+  }
+}
+
+describe('selectRecentFailure', () => {
+  it('returns null on cold-start (<3 builds)', () => {
+    const r = selectRecentFailure({ history: [build({}), build({})], todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.lesson).toBeNull()
+  })
+
+  it('prefers matching archetype', () => {
+    const history = [
+      build({ buildId: 'old-gw', archetype: 'Gallery Wall' }),
+      build({ buildId: 'old-sp', archetype: 'Specimen', date: '2026-04-14' }),
+      build({ buildId: 'old-sc', archetype: 'Scroll' }),
+    ]
+    const r = selectRecentFailure({ history, todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.lesson).toContain('2026-04-14')
+    expect(r.selectedBuildId).toBe('old-sp')
+  })
+
+  it('falls back to any archetype when none match', () => {
+    const history = [
+      build({ buildId: 'old-gw', archetype: 'Gallery Wall' }),
+      build({ buildId: 'old-sc', archetype: 'Scroll' }),
+      build({ buildId: 'old-st', archetype: 'Stack' }),
+    ]
+    const r = selectRecentFailure({ history, todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.lesson).toBeTruthy()
+  })
+
+  it('skips builds where usedInPromptFor >= 2', () => {
+    const history = [
+      build({ buildId: 'used', usedInPromptFor: ['2026-04-15', '2026-04-16'] }),
+      build({ buildId: 'a' }),
+      build({ buildId: 'b' }),
+    ]
+    const r = selectRecentFailure({ history, todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.selectedBuildId).not.toBe('used')
+  })
+
+  it('returns null when all passing (no overallScore ≤ 3)', () => {
+    const history = [
+      build({ overallScore: 5 }),
+      build({ overallScore: 5 }),
+      build({ overallScore: 4 }),
+    ]
+    const r = selectRecentFailure({ history, todayArchetype: 'Specimen', today: '2026-04-17' })
+    expect(r.lesson).toBeNull()
+  })
+})

--- a/tests/utils/read-responsive-history.test.js
+++ b/tests/utils/read-responsive-history.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm, mkdir, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { readResponsiveHistory } from '../../scripts/utils/read-responsive-history.js'
+
+describe('readResponsiveHistory', () => {
+  let root
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'rh-'))
+  })
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  async function plantBuild(date, buildId, metrics) {
+    const dir = path.join(root, 'archive', date, `build-${buildId}`)
+    await mkdir(dir, { recursive: true })
+    await writeFile(path.join(dir, 'responsive-metrics.json'), JSON.stringify(metrics))
+  }
+
+  it('returns empty array when no archive exists', async () => {
+    expect(await readResponsiveHistory({ root, limit: 10 })).toEqual([])
+  })
+
+  it('reads metrics across multiple dates, newest first', async () => {
+    await plantBuild('2026-04-10', '1', { buildId: '1', overallScore: 3 })
+    await plantBuild('2026-04-12', '2', { buildId: '2', overallScore: 5 })
+    await plantBuild('2026-04-11', '3', { buildId: '3', overallScore: 4 })
+    const h = await readResponsiveHistory({ root, limit: 10 })
+    expect(h.map(m => m.buildId)).toEqual(['2', '3', '1'])
+  })
+
+  it('respects limit', async () => {
+    await plantBuild('2026-04-10', '1', { buildId: '1', overallScore: 3 })
+    await plantBuild('2026-04-11', '2', { buildId: '2', overallScore: 5 })
+    await plantBuild('2026-04-12', '3', { buildId: '3', overallScore: 4 })
+    const h = await readResponsiveHistory({ root, limit: 2 })
+    expect(h.length).toBe(2)
+    expect(h[0].buildId).toBe('3')
+  })
+})

--- a/tests/utils/responsive-scorer.test.js
+++ b/tests/utils/responsive-scorer.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { chromium } from '@playwright/test'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { scoreResponsive } from '../../scripts/utils/responsive-scorer.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const FIXTURES = path.join(__dirname, '../fixtures/responsive')
+const fixtureUrl = (name) => `file://${path.join(FIXTURES, name)}`
+
+describe('responsive-scorer', () => {
+  let browser
+  beforeAll(async () => {
+    browser = await chromium.launch({ headless: true })
+  }, 30_000)
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  describe('horizontalScroll check', () => {
+    it('flags horizontal overflow at 360px', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('overflow-horizontal.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.horizontalScroll).toBe(true)
+    }, 30_000)
+
+    it('does not flag clean pages', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.horizontalScroll).toBe(false)
+    }, 30_000)
+  })
+})

--- a/tests/utils/responsive-scorer.test.js
+++ b/tests/utils/responsive-scorer.test.js
@@ -57,4 +57,24 @@ describe('responsive-scorer', () => {
       expect(metrics.viewports.mobile.checks.clippedElements).toEqual([])
     }, 30_000)
   })
+
+  describe('headerOverlap check', () => {
+    it('flags overlapping header children', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('header-overlap.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.headerOverlap.length).toBeGreaterThan(0)
+    }, 30_000)
+
+    it('does not flag non-overlapping header', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.headerOverlap).toEqual([])
+    }, 30_000)
+  })
 })

--- a/tests/utils/responsive-scorer.test.js
+++ b/tests/utils/responsive-scorer.test.js
@@ -147,4 +147,44 @@ describe('responsive-scorer', () => {
       expect(metrics.viewports.desktop.checks.lineLengthFailures).toEqual([])
     }, 30_000)
   })
+
+  describe('scoring math', () => {
+    it('clean page scores 5 at every viewport', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [
+          { name: 'mobile', width: 360, height: 640 },
+          { name: 'desktop', width: 1440, height: 900 },
+        ],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.score).toBe(5)
+      expect(metrics.viewports.desktop.score).toBe(5)
+      expect(metrics.overallScore).toBe(5)
+    }, 30_000)
+
+    it('overflow page scores <5 at mobile and overall = min(viewports)', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('overflow-horizontal.html'),
+        [
+          { name: 'mobile', width: 360, height: 640 },
+          { name: 'desktop', width: 1440, height: 900 },
+        ],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.score).toBeLessThan(5)
+      expect(metrics.overallScore).toBe(metrics.viewports.mobile.score)
+    }, 30_000)
+
+    it('emits worstFailure for bad build', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('overflow-horizontal.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.worstFailure).toBeTruthy()
+      expect(metrics.worstFailure.viewport).toBe('mobile')
+      expect(metrics.worstFailure.check).toBeTruthy()
+    }, 30_000)
+  })
 })

--- a/tests/utils/responsive-scorer.test.js
+++ b/tests/utils/responsive-scorer.test.js
@@ -77,4 +77,25 @@ describe('responsive-scorer', () => {
       expect(metrics.viewports.mobile.checks.headerOverlap).toEqual([])
     }, 30_000)
   })
+
+  describe('bodyTextSize check', () => {
+    it('flags body text below 16px', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('tiny-body.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.bodyTextSize.min).toBeLessThan(16)
+      expect(metrics.viewports.mobile.checks.bodyTextSize.passing).toBe(false)
+    }, 30_000)
+
+    it('passes on 16px body', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.bodyTextSize.passing).toBe(true)
+    }, 30_000)
+  })
 })

--- a/tests/utils/responsive-scorer.test.js
+++ b/tests/utils/responsive-scorer.test.js
@@ -127,4 +127,24 @@ describe('responsive-scorer', () => {
       expect(metrics.viewports.mobile.checks.tapTargetFailures).toEqual([])
     }, 30_000)
   })
+
+  describe('lineLengthFailures check', () => {
+    it('flags paragraphs with average line length > 75 chars', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('long-lines.html'),
+        [{ name: 'desktop', width: 1440, height: 900 }],
+        { browser }
+      )
+      expect(metrics.viewports.desktop.checks.lineLengthFailures.length).toBeGreaterThan(0)
+    }, 30_000)
+
+    it('passes when max-width constrains lines', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'desktop', width: 1440, height: 900 }],
+        { browser }
+      )
+      expect(metrics.viewports.desktop.checks.lineLengthFailures).toEqual([])
+    }, 30_000)
+  })
 })

--- a/tests/utils/responsive-scorer.test.js
+++ b/tests/utils/responsive-scorer.test.js
@@ -36,4 +36,25 @@ describe('responsive-scorer', () => {
       expect(metrics.viewports.mobile.checks.horizontalScroll).toBe(false)
     }, 30_000)
   })
+
+  describe('clippedElements check', () => {
+    it('flags elements extending past the viewport', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clipped-hero.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.clippedElements.length).toBeGreaterThan(0)
+      expect(metrics.viewports.mobile.checks.clippedElements[0].tag).toBe('DIV')
+    }, 30_000)
+
+    it('does not flag clean pages', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.clippedElements).toEqual([])
+    }, 30_000)
+  })
 })

--- a/tests/utils/responsive-scorer.test.js
+++ b/tests/utils/responsive-scorer.test.js
@@ -98,4 +98,33 @@ describe('responsive-scorer', () => {
       expect(metrics.viewports.mobile.checks.bodyTextSize.passing).toBe(true)
     }, 30_000)
   })
+
+  describe('tapTargetFailures check', () => {
+    it('flags links/buttons under 44x44 at mobile', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('small-tap-targets.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.tapTargetFailures.length).toBeGreaterThanOrEqual(2)
+    }, 30_000)
+
+    it('does not flag at desktop width', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('small-tap-targets.html'),
+        [{ name: 'desktop', width: 1440, height: 900 }],
+        { browser }
+      )
+      expect(metrics.viewports.desktop.checks.tapTargetFailures).toEqual([])
+    }, 30_000)
+
+    it('passes on clean page', async () => {
+      const metrics = await scoreResponsive(
+        fixtureUrl('clean.html'),
+        [{ name: 'mobile', width: 360, height: 640 }],
+        { browser }
+      )
+      expect(metrics.viewports.mobile.checks.tapTargetFailures).toEqual([])
+    }, 30_000)
+  })
 })


### PR DESCRIPTION
## Summary

- Measure every daily build at 4 viewports (360 / 768 / 1024 / 1440) with a 6-check scorer: horizontal scroll, content clipping, header overlap, body text size, tap-target size, line length
- Write `responsive-metrics.json` + `viewports/*.png` to each build archive (soft-fail, only runs if dev server is up)
- Inject yesterday's worst failure into today's designer prompt (gated by `RESPONSIVE_FEEDBACK_LOOP=1`; archetype-scoped; reuse-capped at 2)
- New `/dev` responsive card (above rating inputs) + `/dev/responsive` trend dashboard
- Mobile-first responsive section in `unified-designer.md` + per-archetype mobile strategies in all 8 seed files

## Implementation phases

1. **Measurement** (Tasks 1–11) — scorer + screenshotter + fixture suite + archive integration
2. **Prompt layer** (Tasks 12–13) — unified-designer section + per-seed mobile strategies
3. **/dev rating card** (Tasks 14–15) — server fn + ResponsiveCard component
4. **Feedback loop** (Tasks 16–18) — history reader + lesson selector + env-gated wire-up
5. **Trend dashboard** (Tasks 19–20) — SVG charts + /dev/responsive route + e2e

## Plan deviations worth flagging in review

- **Task 10** integration point moved from `scripts/daily-redesign.js` → `scripts/utils/archiver.js` (where `buildDir` is actually in scope)
- **Tasks 14/19** reused the existing sync `readFileSync` + `ARCHIVE_PATH` pattern in `archive-impl.ts` rather than the plan's async `fs/promises` approach
- **Task 18** feedback injection split across `prompt-builder.js` (keeps sync, appends `context.responsiveLesson` when present) and `design-agents.js` (does async history+selector lookup where `chosenArchetype` is in scope)

## Review fixes applied on top of the implementation

- Split `DevPanel` to avoid a React hooks-ordering crash on in-app navigation between `/dev` and `/dev/responsive`
- Thread `archetype` into `responsive-metrics.json` (was silently `null`, breaking archetype-matched selector + trend grouping)
- Add 30s timeout and switch `page.goto` to `waitUntil: 'load'` to avoid hangs against Vite's HMR websocket
- Use `ROOT` for the `usedInPromptFor` writeback path instead of a relative string
- Point trend dashboard "worst builds" links at `/archive/{date}` (deep links to `/dev?date=...` weren't being parsed)

## Test plan

- [x] `pnpm test` — 280/280 passing (unit + integration)
- [x] `pnpm exec playwright test --project=dev-panel` — 5 pass, 1 skip (the skip is the rating-card panel test, which needs a real pipeline build with `responsive-metrics.json`; once one exists in `archive/`, the conditional skip flips off)
- [x] `pnpm exec tsc --noEmit` — no new TS errors introduced by this branch
- [ ] Manual: trigger one local build to verify `responsive-metrics.json` + `viewports/*.png` land in the archive
- [ ] Manual: enable `RESPONSIVE_FEEDBACK_LOOP=1` once ≥3 prior builds exist with metrics, verify "Lesson from Recent Builds" appears in the prompt
- [ ] Manual: load `/dev` and `/dev/responsive` and confirm both render

Spec: `docs/superpowers/specs/2026-04-17-responsive-design.md`
Plan: `docs/superpowers/plans/2026-04-17-responsive-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)