### PR TITLE
fix(interpret-signals): scope CLI error-sniff to MOCK_MODE only

### DIFF
--- a/scripts/interpret-signals.js
+++ b/scripts/interpret-signals.js
@@ -469,11 +469,21 @@ async function main() {
   const elapsed = ((Date.now() - start) / 1000).toFixed(1)
   console.log(`  Claude responded in ${elapsed}s`)
 
-  // Detect error responses that look like success
-  const errorPatterns = ['Prompt is too long', 'context window', 'maximum context length', 'token limit']
-  if (responseText.length < 100 || errorPatterns.some(p => responseText.includes(p))) {
-    console.error(`  ERROR: Claude returned an error response: "${responseText.slice(0, 200)}"`)
+  // Detect error responses that look like success.
+  // The Anthropic SDK throws on real errors, so any text returned in API mode is genuine
+  // generation. The pattern sniff exists for the CLI path (MOCK_MODE), where Claude CLI
+  // historically printed errors like "Prompt is too long" to stdout — those would otherwise
+  // be written as the brief and break downstream agents.
+  if (responseText.length < 100) {
+    console.error(`  ERROR: Claude returned suspiciously short response: "${responseText}"`)
     process.exit(1)
+  }
+  if (MOCK_MODE) {
+    const errorPatterns = ['Prompt is too long', 'context window', 'maximum context length', 'token limit']
+    if (errorPatterns.some(p => responseText.includes(p))) {
+      console.error(`  ERROR: Claude CLI returned an error response: "${responseText.slice(0, 500)}"`)
+      process.exit(1)
+    }
   }
 
   // Step 3: Write brief


### PR DESCRIPTION
## Summary

- The interpret-signals error-sniff was added in 5a10b89 (2026-03-19) for the **CLI path**, where Claude CLI used to print errors like `"Prompt is too long"` to stdout and the script would write them as a brief, breaking downstream agents.
- In **API mode** the Anthropic SDK throws on real errors, so any returned text is genuine generation. The pattern sniff could only produce false positives there — and did, killing the 2026-04-25 nightly run when the brief response happened to contain one of `'Prompt is too long' | 'context window' | 'maximum context length' | 'token limit'`.
- This PR restricts the pattern sniff to `MOCK_MODE`, keeps the length-< 100 sanity check in both modes, and widens the diagnostic slice from 200 → 500 chars so the next CLI false-trigger is debuggable.

## Context

After 2026-04-21, four nightly runs failed with `"Your credit balance is too low"` (resolved by topping up credits). The 2026-04-25 run got past the API but failed on this same `interpret-signals.js` heuristic — see [run 24928618943](https://github.com/marchdoe/doug-march.com/actions/runs/24928618943).

## Test plan

- [x] `pnpm test -- tests/interpret-signals.test.js` — 280 tests pass
- [ ] Trigger a manual run after merge (`gh workflow run daily-redesign.yml`) to confirm end-to-end, OR wait for tonight's 10:00 UTC cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)