### PR TITLE
docs: add TODO.md + 9 implementation specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Welcome to your new TanStack Start app! 
 
+See [TODO.md](./TODO.md) for the current backlog.
+
 # Getting Started
 
 To run this application:

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,95 @@
+# TODO
+
+Last verified against the live repo: 2026-04-27.
+
+Status legend: 🔴 not started · 🟡 partial · ✅ done · ❓ needs answers before spec
+
+---
+
+## Production / API mode
+
+### 1. Pass Awwwards screenshots via API image content blocks ✅ spec ready
+
+→ [`docs/specs/01-awwwards-screenshots-image-blocks.md`](./docs/specs/01-awwwards-screenshots-image-blocks.md)
+
+All three creative agents (interpret-signals, token-designer, unified-designer) receive base64 image blocks fetched once at signal-collection time. URL blocks rejected for reliability. Fetch failures degrade gracefully to text-only.
+
+---
+
+### 2. Split unified designer into Designer + React Engineer ✅ spec ready
+
+→ [`docs/specs/02-designer-engineer-split.md`](./docs/specs/02-designer-engineer-split.md)
+
+Mockup designer (Opus 4.7) → mockup-critic → React engineer (Sonnet 4.6). Standalone HTML/CSS mockup is naturally archive-friendly. Hard replace; cleans up orphan prompts from the previous component-level split.
+
+---
+
+### 3. Token Designer chaos mode ✅ spec ready
+
+→ [`docs/specs/03-token-chaos-mode.md`](./docs/specs/03-token-chaos-mode.md)
+
+5 vibes (Brutalist · Editorial · Album-Cover · Hyper-Modern Brand · Programmer-Aesthetic) applied to BOTH palette (token-designer prompt extension) AND typography (5 new chassis catalog entries). Risk-weight gated: 5 = today's behavior, 7 = vibe-anchored, 9 = max-axes. No new env vars; extends existing creative-weights and chassis systems.
+
+---
+
+## Site features
+
+### 4. Loading states on archive routes ✅ spec ready
+
+→ [`docs/specs/04-archive-loading-states.md`](./docs/specs/04-archive-loading-states.md)
+
+Skeleton rows on the index page, skeleton sections on the detail page. Plain CSS pulse animation, no new dependencies. Distinct empty state preserved for genuinely empty archives.
+
+---
+
+### 5. Archive visual redesign + mark-as-reference (owner-only) ✅ spec ready
+
+→ [`docs/specs/05-archive-visual-redesign.md`](./docs/specs/05-archive-visual-redesign.md)
+
+Visual upgrade only — archive keeps its fixed identity, doesn't participate in the daily redesign. Index rows get thumbnail + text layout; detail page leads with hero screenshot. Brings back "Mark as reference" UI from commit `d91b3e1`, dev-mode-gated like the existing dev panel.
+
+---
+
+## Pipeline polish
+
+### 6. Pipeline variance (instrumentation + soft guidance) ✅ spec ready
+
+→ [`docs/specs/06-pipeline-variance.md`](./docs/specs/06-pipeline-variance.md)
+
+Extends the existing `color-mandate.js` pattern with parallel utilities for archetype and chassis variance. Adds a `/dev/variance` dashboard mirroring the existing `/dev/responsive`. Soft guidance only — never blocks the model from picking what fits. "Fit > novelty" is the guiding principle, repeated in every variance prompt section.
+
+---
+
+### 7. Bump Claude CLI past 2.1.92 ✅ spec ready
+
+→ [`docs/specs/07-claude-cli-version-bump.md`](./docs/specs/07-claude-cli-version-bump.md)
+
+**Cost: $0 for discovery.** Test loop runs locally on Max plan auth — CLI binary and prompt-handling behavior are identical in both environments. Final CI dry-run as a confidence check (~$2). Binary-search fallback if `2.1.120` fails.
+
+---
+
+## Housekeeping
+
+### 8. Close resolved pipeline-failure issues ✅ spec ready
+
+→ [`docs/specs/08-close-pipeline-failure-issues.md`](./docs/specs/08-close-pipeline-failure-issues.md)
+
+Triage 8 open issues. Close 5 with known causes (PR #55 + credits top-up). Investigate #43, #45, #48 by pulling their failed run logs and categorizing — close, relabel, or consolidate into a real bug ticket.
+
+---
+
+### 9. Dependabot alert #325 (follow-redirects) ✅ spec ready
+
+→ [`docs/specs/09-dependabot-follow-redirects.md`](./docs/specs/09-dependabot-follow-redirects.md)
+
+Add `pnpm.overrides` entry pinning `follow-redirects` to `^1.16.0`. Verify with `pnpm test` + `pnpm build`. ~15 min of work.
+
+---
+
+## Done (recent)
+
+- [x] Responsive design pipeline (PR #49, 2026-04-20)
+- [x] Interpret-signals false-positive in API mode (PR #55, 2026-04-26)
+- [x] CI security hardening (PR #41)
+- [x] Pipeline reliability — archetype extraction, retry handling, build smoke tests (PR #37, #41)
+- [x] "Save as Reference" button — removed from code

--- a/docs/specs/01-awwwards-screenshots-image-blocks.md
+++ b/docs/specs/01-awwwards-screenshots-image-blocks.md
@@ -1,0 +1,83 @@
+# Spec 01 — Awwwards screenshots via API image content blocks
+
+**Status:** ready to execute
+**Depends on:** API mode (already live as of 2026-04-26)
+**Mode scope:** API path only — MOCK_MODE keeps the current text-only behavior
+
+## Goal
+
+Today the pipeline drops Awwwards SOTD screenshots and only sends the title + description as text to Claude. Replace that with native API image content blocks so all three creative agents have the actual visual reference, not a name.
+
+## Decisions
+
+| Question | Decision |
+|---------|----------|
+| Which agents receive the screenshots | All three: `interpret-signals`, `token-designer`, `unified-designer` |
+| Source format | **base64**, fetched once at signal-collection time |
+| Number of screenshots per run | **3** (matches current text cap) |
+| Failure handling | If a screenshot fetch fails, skip that one and continue. If all 3 fail, downstream agents fall back to text-only. Never hard-fail the pipeline on inspiration assets. |
+| MOCK_MODE | unchanged — CLI stdin can't carry binary content blocks. Image blocks live entirely on the API path. |
+
+**Why base64 over URL blocks:**
+- URL blocks force Anthropic to re-fetch on every agent call (3 agents × signal day = 9 fetches). Any awwwards.com hiccup mid-run cascades.
+- We already have a signal-collection stage with retry/skip semantics for flaky providers. Fetch once there, persist bytes, and downstream stages get deterministic input.
+- Cost delta is negligible — typical og:image PNGs are 100–500KB; 3 × ~300KB ≈ 1MB payload bump per call.
+
+## Implementation outline
+
+### 1. Signal collection — download bytes
+
+`scripts/signals/awwwards.js` already extracts `screenshot_url` from each SOTD's `og:image` (line 75). Extend the collector to:
+
+- Download the bytes for each `screenshot_url` in the top 3 sites
+- Convert to base64
+- Store on the site object as `screenshot_b64` + `screenshot_media_type` (e.g. `image/png`, `image/jpeg`)
+- On fetch failure, log a warning, omit the b64 fields, and continue
+
+Persisted output: `signals/today.yml` gets `screenshot_b64` per site (or, if YAML payload size is a concern, write a sibling `signals/today.images.json` keyed by site URL — see "Storage format" below).
+
+### 2. Pipeline calls — pass image blocks
+
+Three call sites need to thread image content blocks into the user message:
+
+- `scripts/interpret-signals.js` — `callAnthropicAPI` (line 358) currently sends `messages: [{role: 'user', content: prompt}]`. Switch to a content array:
+  ```js
+  content: [
+    ...screenshots.map(s => ({
+      type: 'image',
+      source: { type: 'base64', media_type: s.media_type, data: s.b64 },
+    })),
+    { type: 'text', text: prompt },
+  ]
+  ```
+- `scripts/design-agents.js` — `callAgent` flows for `token-designer` and `unified-designer`. Image blocks attach to the user prompt the same way. The `screenshot-critic` already uses base64 image markdown — that path stays unchanged.
+
+### 3. Signal-collection failure semantics
+
+- Each screenshot fetch is independent. One 404 doesn't block the others.
+- If 0 of 3 succeed, agents fall back to text-only — same as today.
+- Log every fetch result so failures are visible in CI logs without breaking the build.
+
+### 4. Storage format (decide during implementation)
+
+Two options, low-stakes:
+
+- **(a)** Add `screenshot_b64` + `screenshot_media_type` directly to each site object in `signals/today.yml`. Simplest. YAML grows by ~1MB.
+- **(b)** Sidecar file `signals/today.images.json` keyed by `slug` or `url`. Keeps YAML readable.
+
+Default to **(a)** unless review of the resulting `today.yml` size is unwieldy.
+
+## Acceptance criteria
+
+- [ ] A scheduled run in API mode produces a brief that references visual elements only the screenshot reveals (e.g., "the SOTD's left-aligned serif masthead" rather than just "Title X")
+- [ ] If `og:image` URL returns 404 for one of the 3 sites, run completes successfully with the other 2 + a warning log
+- [ ] If all 3 fail, run completes with text-only references — current behavior preserved
+- [ ] MOCK_MODE local runs unaffected (no image blocks emitted via CLI)
+- [ ] `today.yml` (or sidecar) is human-readable enough to spot-check
+- [ ] Token cost per run within ~10% of pre-change baseline (image tokens add up but Haiku 4.5 image costs are modest)
+
+## Risks / open during implementation
+
+- Anthropic API image input limits — confirm current per-image and per-request size caps. Resize to ≤1568px on long edge if needed.
+- Awwwards `og:image` URLs occasionally point at JPEG, sometimes PNG. Detect content-type from response headers, don't assume.
+- Cache hit interaction — if we use prompt caching, image blocks should be at the front of the content array so they're cacheable across the run's sibling agents on the same day.

--- a/docs/specs/02-designer-engineer-split.md
+++ b/docs/specs/02-designer-engineer-split.md
@@ -1,0 +1,134 @@
+# Spec 02 — Designer / React Engineer split
+
+**Status:** ready to execute
+**Depends on:** none (independent of Spec 01)
+**Mode scope:** API path. MOCK_MODE inherits the same orchestration; CLI calls per-agent stay text-only.
+
+## Goal
+
+Replace `unified-designer` (one agent that does both visual design and React/Panda translation) with two agents in series:
+
+1. **Mockup designer** — produces a self-contained HTML/CSS mockup
+2. **React engineer** — translates mockup → React/Panda implementation
+
+Two outcomes drive this:
+
+- **Better designs.** Splitting visual taste from React mechanics removes cognitive load from the agent making composition decisions.
+- **A real design archive.** A standalone HTML mockup is naturally archivable — every day produces a static file that can be opened directly without the dev server, giving the archive page real "scrub through prior days" depth.
+
+## Prior art — important context
+
+There was a previous multi-agent split (`scripts/prompts/sidebar-designer.md`, `footer-designer.md`, `structure-agent.md`, `component-agent.md`) that was consolidated back into `unified-designer` on branch `feat/designer-unify`. Those files are orphaned in the repo today.
+
+The earlier split was **by component** — every component-agent had to redo design judgment for its slice. This new split is **by role** — one designer makes all visual decisions in one shot; one engineer does pure translation. Categorically different concern. Cleanup of the orphaned by-component prompts is part of this spec.
+
+## Decisions
+
+| Question | Decision | Rationale |
+|---------|----------|-----------|
+| Mockup designer model | **Opus 4.7** | `unified-designer` already runs on Opus today — taste-critical work. No change. |
+| React engineer model | **Sonnet 4.6** | Mechanical HTML/CSS → React/Panda translation. Sonnet handles complex code translation well; Haiku risks losing CSS subtleties. |
+| Designer output format | **Standalone HTML/CSS document** | Self-contained, no runtime deps, archive-ready. Inline `<style>` block, no external dependencies, no React. |
+| Spec-critic position | **Both** — existing spec-critic (visual spec review) **+** new mockup-critic (HTML/CSS review before engineering) | Catches taste issues before they're locked into React. screenshot-critic still reviews final rendered output. |
+| Rollout | **Hard replace** | `unified-designer.md` is retired. No fallback path. Existing retry/fallback machinery in `design-agents.js` is reused on the new agents. |
+
+### What stays unchanged (extend, do not overwrite)
+
+| Asset | Why it stays |
+|-------|-------------|
+| `design-director.md` | Produces the visual spec — input to mockup-designer |
+| `spec-critic.md` | Reviews the visual spec (existing flow) |
+| `token-designer.md` | Produces design tokens — both new agents read them. (Chaos mode is Spec 03.) |
+| `screenshot-critic.md` | Reviews final rendered React output |
+| `library-*.md` (color, layout, typography, components) | Referenced by both mockup-designer and react-engineer |
+| `design-system-reference.md` | Referenced by both new agents |
+
+### What's new
+
+- `scripts/prompts/mockup-designer.md`
+- `scripts/prompts/react-engineer.md`
+- `scripts/prompts/mockup-critic.md`
+
+### What's removed
+
+- `scripts/prompts/unified-designer.md`
+- `scripts/prompts/sidebar-designer.md` (orphan from prior split)
+- `scripts/prompts/footer-designer.md` (orphan from prior split)
+- `scripts/prompts/structure-agent.md` (orphan from prior split)
+- `scripts/prompts/component-agent.md` (orphan from prior split)
+
+## Implementation outline
+
+### 1. Mockup designer (`mockup-designer.md`)
+
+Inputs:
+- Visual spec (from design-director)
+- Design tokens (from token-designer)
+- Awwwards screenshots — image content blocks once Spec 01 lands
+- Today's signals brief
+
+Output: a single HTML file with inline `<style>` and inline SVGs (no external assets). No React, no Panda, no JS frameworks. Real content from the portfolio data, not lorem ipsum.
+
+The prompt should explicitly tell it: "you are not writing React. you are designing a website. the engineer will translate your work."
+
+### 2. Mockup critic (`mockup-critic.md`)
+
+Reads the HTML/CSS mockup and returns either `APPROVE` or `REVISE` + feedback. Reviews:
+- Composition matches the visual spec's archetype declaration
+- Token usage matches the token-designer's preset (no off-palette colors)
+- Mobile/responsive section present (post-PR #49 requirement)
+- No obvious dead-end CSS (z-index spaghetti, broken positioning)
+
+On `REVISE`, the mockup-designer gets one revision attempt, mirroring the existing spec-critic loop.
+
+### 3. React engineer (`react-engineer.md`)
+
+Inputs:
+- The approved HTML/CSS mockup
+- Design tokens preset
+- Library references (color/layout/typography/components)
+- Technical contracts (route file paths, what each file must export)
+
+Output: the same set of files `unified-designer` produces today — `app/components/Layout.tsx`, `Sidebar.tsx`, route files, `elements/preset.ts`, `elements/__root.tsx`. Translation only — no design re-decisions.
+
+The prompt should be strict: "if the mockup says it, you implement it. do not improve it. do not adapt it. translate."
+
+### 4. Pipeline orchestration (`scripts/design-agents.js`)
+
+Replace the single `unified-designer` call (`design-agents.js:1052`) with:
+
+```
+mockup = callAgent('mockup-designer', ..., { model: 'opus' })
+critique = callAgent('mockup-critic', mockup, { model: 'haiku' })
+if (critique.verdict === 'REVISE') mockup = callAgent('mockup-designer', ..., revisionPrompt)
+files = callAgent('react-engineer', { mockup, tokens, libraries }, { model: 'sonnet' })
+```
+
+Reuse the existing retry-on-build-error path — replace `'unified-designer'` with `'react-engineer'` in:
+- `STRUCTURE_FILES.map(...)` and `COMPONENT_FILES.map(...)` ownership table (`design-agents.js:55-57`)
+- All `responsibleAgent === 'unified-designer'` branches in screenshot-critic and build-failure retry blocks
+
+### 5. Archive integration
+
+- Save the approved mockup to `public/archive/$date/mockup.html` during the build step
+- Add `mockupPath` (or just rely on convention) to `public/archive/$date/_detail.json`
+- `app/routes/archive.$date.tsx` — add a "Mockup" link/section near the existing "View archived site" anchor (~line 514). Open in new tab; could also embed in an iframe with a "fullscreen" affordance.
+- Archive index (`app/routes/archive.tsx`) gets no changes — the row layout still surfaces archetype + brief.
+
+## Acceptance criteria
+
+- [ ] Three new prompt files exist and are wired through `callAgent`
+- [ ] Five orphan prompts deleted
+- [ ] One scheduled run completes end-to-end producing both mockup.html and React output
+- [ ] Mockup opens in a browser with no JS errors and no missing assets
+- [ ] Live site (React build) visually matches mockup at desktop breakpoint (eye test, 3 consecutive days)
+- [ ] Archive detail page exposes the mockup link
+- [ ] Run cost increase ≤ +$0.50/run versus unified baseline
+- [ ] No regression in screenshot-critic pass rate over 5 days
+
+## Risks
+
+- **Translation fidelity loss.** React engineer might subtly drift from the mockup. Mitigation: mockup-critic catches taste issues before engineering; screenshot-critic catches them after. If drift becomes recurring, tighten react-engineer prompt with diff-style examples.
+- **Cost.** Adding a Sonnet call per run. Tracked; tolerable per the "best model per role" directive.
+- **Re-introducing the consolidation pain.** Past split failed because component-level agents duplicated design judgment. This split puts all design judgment in one agent; engineer is downstream and dumb. Different shape — should not recreate the problem, but worth flagging in the postmortem if quality regresses.
+- **Opus availability.** Same risk as today (unified is on Opus). No new exposure.

--- a/docs/specs/03-token-chaos-mode.md
+++ b/docs/specs/03-token-chaos-mode.md
@@ -1,0 +1,149 @@
+# Spec 03 — Chaos mode (palette + typography)
+
+**Status:** ready to execute
+**Depends on:** none (independent of Specs 01 and 02)
+**Mode scope:** API + MOCK_MODE — chassis catalog and prompt changes apply uniformly
+
+## Goal
+
+Push the daily design toward bolder, more characterful palettes and typography when the risk dial is high. Today's pipeline already biases toward vibrancy, but the directives are generic ("BOLD, EXPERIMENTAL") with no concrete commitment to an aesthetic vibe. Chaos mode supplies that commitment via 5 named aesthetic vibes — at high risk, the agents pick one vibe and follow its rules.
+
+## Existing systems we're extending (DO NOT overwrite)
+
+This spec is layered on top of three systems that already work:
+
+| System | Where | Today's behavior |
+|--------|-------|-----------------|
+| Creative weights | `scripts/interpret-signals.js:383-388`, `scripts/design-agents.js:425-491` | All four weights (signals, inspiration, ratings, risk) are env-var driven, default 5/10, already injected into every agent's prompt via `weightsPrompt` |
+| Risk directive | `scripts/design-agents.js:491` | When `WEIGHT_RISK >= 7`, every agent receives `"The owner wants BOLD, EXPERIMENTAL design today. Push boundaries."`. When `<= 3`, receives `"SAFE, POLISHED design today. Proven patterns."`. Otherwise nothing. |
+| Typography chassis | `elements/chassis/index.js` + `scripts/utils/chassis.js` | Director picks one entry from `CHASSIS_CATALOG` based on mood + archetype tags. Orchestrator deterministically merges fonts + fontSizes. v1 scope: fonts + scale ratio only — spacing/colors stay with token-designer. Catalog today has 2 entries. |
+| Color philosophy | `scripts/prompts/token-designer.md:7` | "Favor vibrancy by default. Most days should feel alive — saturated accents, warm or cool but never grey." Default already biases bold. |
+
+**No new env vars. No new orchestration paths. No new agents.** Chaos is a content/catalog change.
+
+## Decisions
+
+| Question | Decision |
+|----------|----------|
+| Trigger | Reuse `WEIGHT_RISK` (already wired everywhere) |
+| Levels | `<= 4` safe · `5–6` default vibrancy (current behavior) · `>= 7` chaos vibe-anchored · `>= 9` chaos max-axes |
+| Domains affected | **Color** (palette count, harmony, saturation) — token-designer prompt extension. **Typography** (font pairing, scale ratio) — new chassis entries. |
+| Vibe count | 5 — applied to both domains so a "brutalist" day produces brutalist tokens *and* a brutalist chassis |
+| Vibe selection | The agent picks ONE vibe per run, based on today's brief mood. Commits fully — no blending. At risk ≥ 9, the chosen vibe's most extreme axes are pushed. |
+
+## The 5 vibes
+
+Each vibe is a named aesthetic that can be referenced from both the chassis catalog and the token-designer prompt. Vibe names below; concrete rules in implementation sections.
+
+| Vibe | Mood signature |
+|------|----------------|
+| **Brutalist Web** | Anti-design, raw, system fonts, single-accent collision |
+| **Editorial / Magazine** | Refined, type-driven hierarchy, generous whitespace, muted palette + warm accent |
+| **Album-Cover / Poster** | Photographic-feeling, intentional tonal collisions, display face dominance |
+| **Hyper-Modern Brand** | Stark, single-hero color, custom-feeling display + clean grotesk |
+| **Programmer-Aesthetic** | Mono-dominant, primary colors against neutral, dense info |
+
+## Implementation outline
+
+### Part A — Typography chaos (chassis catalog)
+
+`elements/chassis/` currently ships 2 entries. Add 5 new chassis — one per vibe. Each chassis is a real Google Fonts pairing with weights, scale ratio, and mood/archetype tags (existing convention, see `elements/chassis/types.js`).
+
+Suggested chassis (final font picks made during execution):
+
+| Vibe | Chassis name | Heading | Body | Scale | Tagged moods |
+|------|------|---------|------|-------|--------------|
+| Brutalist Web | `space-mono-system` | Space Mono | system-ui | 2.0 | raw, defiant, anti-design |
+| Editorial | `dm-serif-display-inter` (companion to existing `playfair-outfit`) | DM Serif Display | Inter | 1.618 | refined, contemplative, dense |
+| Album-Cover | `bodoni-moda-inter` | Bodoni Moda | Inter | 1.5 | dramatic, photographic, contrast |
+| Hyper-Modern Brand | `inter-tight-extreme` | Inter Tight Black | Inter Regular | 2.0 | stark, branded, confident |
+| Programmer-Aesthetic | `jetbrains-mono-only` | JetBrains Mono | JetBrains Mono | 1.25 | technical, dense, deliberate |
+
+For each:
+1. Verify all weights exist on `fonts.google.com/specimen/<family>` (per existing chassis convention)
+2. Author the chassis file (`elements/chassis/<name>.js`)
+3. Tag with moods + archetypes
+4. Append to `CHASSIS_CATALOG` in `elements/chassis/index.js`
+5. Run `scripts/preview-chassis.js` to render proofs
+
+The Director's chassis-selection logic already filters by mood/archetype — at high risk, the bolder chassis become eligible naturally because the brief uses bolder mood language.
+
+### Part B — Color chaos (token-designer prompt extension)
+
+Extend `scripts/prompts/token-designer.md` with a new section: `## Chaos Mode (when the risk weight indicates BOLD)`.
+
+This section sits *after* the existing "Color Philosophy" and "Color Mandate" sections so they remain the baseline. Triggered by the existing `BOLD, EXPERIMENTAL` directive that token-designer already receives via `weightsPrompt`.
+
+Section contents:
+
+```
+When today's risk directive says "BOLD, EXPERIMENTAL" — commit to ONE of these
+five vibes for your palette. Pick what FITS the brief, not what's most extreme.
+
+1. Brutalist Web — 2-3 colors max. One fully-saturated accent (hot pink,
+   electric blue, magenta, signal red) against pure neutrals (#000, #fff, #f0f0f0).
+   No mid-tones.
+
+2. Editorial / Magazine — 4-6 colors. Refined: burgundy, cream, ink, mustard,
+   forest. Saturation: muted with one warm accent at full saturation.
+
+3. Album-Cover / Poster — 3-5 colors. Photographic-feeling: dusty rose, faded
+   orange, deep navy, washed cream. Medium-high saturation. ONE bold tonal
+   collision (e.g., hot pink anchor against muted earth).
+
+4. Hyper-Modern Brand — 3 colors total. One hero (saturated, signature) +
+   black + white. OR hero + one muted neutral + white. Stark.
+
+5. Programmer-Aesthetic — Primary colors (red/yellow/blue) at full saturation
+   against neutral background. No tints. Bold borders. Color-as-data.
+
+Pick ONE. Commit. Do not blend.
+
+If the risk weight is >= 9 ("MAX CHAOS"), push the chosen vibe's defining
+axis harder:
+- Brutalist: drop to 2 colors only, push accent to neon
+- Editorial: tighten to 4 colors, increase scale contrast (matches chassis)
+- Album-Cover: amplify the tonal collision
+- Hyper-Modern Brand: 2 colors only (hero + black, no neutrals)
+- Programmer-Aesthetic: stay 3 colors, push to fluorescent primary
+
+Coordinate with the chassis. If today's chassis is `space-mono-system`, lean
+Brutalist. If `bodoni-moda-inter`, lean Album-Cover. If `jetbrains-mono-only`,
+lean Programmer. The chassis tells you the typography vibe — your job is the
+coherent color answer to that vibe.
+```
+
+### Part C — Verify chassis identifier reaches token-designer
+
+The chassis vibe coordination in Part B requires token-designer to know which chassis was selected. Today's flow: Director picks chassis → orchestrator merges into preset → token-designer runs.
+
+**During execution, verify** that token-designer's user prompt receives the chassis name (or at minimum, its mood/archetype tags). If not, thread the chassis identifier through `buildAgentPrompt` for `token-designer`. Small change — call out in the implementation PR.
+
+### Part D — Workflow override (optional)
+
+Add `WEIGHT_RISK` as a `workflow_dispatch` input in `.github/workflows/daily-redesign.yml` so manual runs can dial chaos up without editing code. Cron default stays whatever you decide (5 = current; 7 = bias toward chaos every day).
+
+## Acceptance criteria
+
+- [ ] All 5 new chassis entries exist, render correctly via `scripts/preview-chassis.js`, and pass the existing chassis tests
+- [ ] `CHASSIS_CATALOG` length = 7 (2 existing + 5 new)
+- [ ] Token-designer prompt has the chaos section, layered after existing Color Philosophy (not replacing it)
+- [ ] At `WEIGHT_RISK=5`, output is statistically similar to today's baseline (no regression)
+- [ ] At `WEIGHT_RISK=8` over 5 manual runs, all 5 vibes appear at least once in the chassis selection log
+- [ ] At `WEIGHT_RISK=10`, output is visibly more extreme on the chosen vibe's axis (eye test)
+- [ ] Body-text contrast meets WCAG AA (4.5:1) at every chaos level — readability is non-negotiable
+- [ ] No breakage in existing `playfair-outfit` and `space-grotesk-work-sans` selection paths
+- [ ] Token-designer receives chassis identifier in its user prompt
+
+## Risks
+
+- **Vibe-chassis mismatch.** If Director picks `bodoni-moda-inter` (Album-Cover chassis) but token-designer picks Programmer color vibe, output is incoherent. Mitigation: token-designer prompt explicitly tells it to coordinate with the chassis (Part B). Spec-critic catches the mismatch in revision loop.
+- **Readability casualties.** Pushed saturation + display fonts can break body legibility. Mitigation: WCAG AA acceptance criterion + `library-color.md` already enforces a contrast floor.
+- **Chassis catalog bloat.** Going from 2 → 7 entries triples Director's selection space. Director currently filters by mood tags — verify filter still produces sensible defaults at low risk (Part D acceptance check).
+- **Google Fonts availability.** Each new chassis depends on a Google-hosted family. Verify each at execution time per the chassis catalog convention.
+
+## Out of scope (future)
+
+- A `WEIGHT_CHAOS` independent dial (could decouple from risk later if desired)
+- Custom / non-Google fonts in chassis (would need self-hosting infrastructure)
+- Auto-vibe-tagging based on signals (currently the agent picks; could become rule-based)

--- a/docs/specs/04-archive-loading-states.md
+++ b/docs/specs/04-archive-loading-states.md
@@ -1,0 +1,79 @@
+# Spec 04 — Archive loading states
+
+**Status:** ready to execute
+**Depends on:** none
+
+## Goal
+
+Stop showing "No archive entries yet." while the archive is still loading, and stop showing a blank white screen on the detail page during fetch. Replace both with skeletons that match the eventual layout.
+
+## Today's bug
+
+- `app/routes/archive.tsx:92-94` — `entries.length === 0 ? "No archive entries yet."` collapses two states into one. Same message for "still fetching" and "actually empty".
+- `app/routes/archive.$date.tsx:149` — `if (!detail) return null` blanks the page during fetch, so users see a flash of nothing before content appears.
+
+## Decisions
+
+| Question | Decision |
+|----------|----------|
+| Loading treatment | **Skeleton** matching the real layout — better UX than a spinner, low extra code |
+| Library | None — render plain divs with muted bg + 1.2s pulse animation. No new dependencies. |
+| Empty state distinct from loading | Yes — empty stays as "No archive entries yet." but only renders after the fetch resolves with zero results |
+| Error state | Detail page already has one (`error` flag); no change. Index page silently swallows fetch errors today (`.catch(() => setLoaded(true))`) — leaves it as "No entries yet" which is wrong for a fetch error, but out of scope here |
+
+## Implementation outline
+
+### `app/routes/archive.tsx`
+
+The component already tracks `loaded`. Use it:
+
+```jsx
+{!loaded ? (
+  // 5 skeleton rows matching ArchiveRow's layout
+  <ArchiveRowSkeleton count={5} />
+) : entries.length === 0 ? (
+  <p style={{...}}>No archive entries yet.</p>
+) : (
+  entries.map(...)
+)}
+```
+
+`ArchiveRowSkeleton`: same flex layout as `ArchiveRow` (lines 117-179) but with two muted-bg blocks (one for archetype label width, one for brief preview line) and a small block on the right for the date. Border-bottom pattern preserved so skeleton rows visually feel like real rows.
+
+### `app/routes/archive.$date.tsx`
+
+Replace `if (!detail) return null` with a skeleton matching the four sections:
+
+1. Header section (archetype kicker + date + h1 brief + rationale paragraphs)
+2. Tokens section (label + 4-color-swatch-row + 2-font-row)
+3. Signals section (label + 3 stacked text blocks)
+4. Actions section (back link)
+
+Skeleton uses muted-bg blocks at the same widths as the real content's typical sizes. Same maxWidth/padding wrappers as the real page so layout doesn't shift on load.
+
+### Pulse animation
+
+Single CSS keyframe in each route file (or a shared util):
+
+```css
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 0.9; }
+}
+```
+
+Applied to the muted-bg blocks. Background color: `var(--colors-border, #e5e5e5)` — already used elsewhere on the page so no new token.
+
+## Acceptance criteria
+
+- [ ] Index page shows skeleton rows while `_data.json` is in flight, then the real list — no flash of "No entries yet"
+- [ ] Detail page shows skeleton sections while `_detail.json` is in flight, then the real content — no flash of blank screen
+- [ ] On a genuinely empty archive (rare — only at first deploy), index shows "No entries yet" *after* fetch resolves
+- [ ] On detail-not-found (404), the existing error message renders unchanged
+- [ ] No layout shift between skeleton and final content (max-widths and padding match)
+- [ ] Pulse animation respects `prefers-reduced-motion` — fall back to static muted bg
+
+## Risks
+
+- **Out-of-scope refactor temptation.** The current `useEffect` + `useState` pattern could be replaced with TanStack Router loaders (which fetch before render and remove the loading state entirely). Cleaner long-term. Not part of this spec — keep the diff small.
+- **Layout shift if skeleton sizes are off.** Mitigation: skeleton block widths derived from typical content widths observed in `_detail.json` samples. Verify in browser at execution time.

--- a/docs/specs/05-archive-visual-redesign.md
+++ b/docs/specs/05-archive-visual-redesign.md
@@ -1,0 +1,117 @@
+# Spec 05 — Archive visual redesign + Mark-as-reference (owner-only)
+
+**Status:** ready to execute
+**Depends on:** Spec 04 (loading skeletons should match the new visual layout)
+
+## Goal
+
+Improve the visual feel of the archive without changing its structure or how it relates to the daily redesign. Plus: bring back the ability to mark an archived design as inspiration for future runs — restricted to the owner.
+
+The archive is a portfolio surface in its own right (not a member of the daily-redesigning live site). It deserves its own permanent identity.
+
+## What we're NOT doing
+
+- The archive does **not** participate in the daily redesign. Its visual language is fixed.
+- No structural changes to navigation, routing, or what the archive contains.
+- No new public features. The mark-as-reference action is private.
+
+## Decisions
+
+| Question | Decision |
+|----------|----------|
+| Archive participates in daily redesign? | **No.** Fixed identity. |
+| Mark-as-reference availability | **Owner-only**, gated to dev mode (matches existing `dev-panel.tsx` pattern — no new auth) |
+| Index row format | **Thumbnail + text** — visual preview alongside archetype + brief |
+| Detail page screenshot position | **Hero at top** — visual product leads, then brief/tokens/signals |
+| Reference library backend | **Existing** — append to `references/index.yml` + copy screenshot. Pipeline already consumes it via `scripts/collect-references.js` |
+
+## Implementation outline
+
+### Part A — Index page visual upgrade (`app/routes/archive.tsx`)
+
+Today: text-only rows (archetype label + truncated brief + date).
+
+New row layout — thumbnail left, text right:
+
+- Thumbnail: ~160×100 (desktop) / ~96×60 (mobile) — preserves aspect ratio with `object-fit: cover`
+- Source: `/archive/$date.png` (the per-day screenshot already produced)
+- Fallback for entries without screenshot: a token-derived placeholder — a small gradient or color-block strip using that day's preset colors. Pulls from `_detail.json` (or the existing `entries` payload — extend it if needed to include preset colors)
+- Text column: archetype kicker (small caps, dim) → brief truncate → date
+- Hover: subtle lift on the thumbnail, brief darkens slightly. No backgroundChange (current row hover swaps bg — drop it, the thumbnail does the visual work now)
+
+Header section keeps "ARCHIVE" / "Daily Redesigns" / intro paragraph but tighten typography: drop h1 to ~28px (it's an archive, not a hero), let the thumbnails carry visual weight.
+
+### Part B — Detail page hero (`app/routes/archive.$date.tsx`)
+
+Reorder sections:
+
+1. **Hero screenshot** (NEW position) — full container width within the existing 720 maxWidth, OR optionally break out to a wider treatment (suggest 1024 max for the screenshot only). 1px border, subtle shadow (`box-shadow: 0 8px 32px rgba(0,0,0,0.08)`), rounded corners (4px).
+   - Caption underneath: archetype + date in a small-caps row
+   - On hover: cursor pointer, opens the live archived HTML (`/archive/$date/index.html`) in a new tab
+2. **Brief section** (moved down, otherwise unchanged) — kicker + h1 brief + rationale
+3. **Tokens section** (unchanged)
+4. **Signals section** (unchanged)
+5. **Actions section** (unchanged) — Back to Archive + View archived site
+
+For days without screenshot: the hero falls back to a styled "no preview" panel (token color blocks arranged into a poster-like composition). Better than skipping the section entirely.
+
+### Part C — Mark-as-reference (owner-only, dev mode only)
+
+Reuse the dev-only gating pattern from `app/dev-panel.tsx`. The button only appears when the site is running in dev mode (`import.meta.env.DEV` or equivalent).
+
+**UI:**
+- A small "★ Mark as reference" button below the hero on the detail page (or in a top-right corner of the hero)
+- Click → reveal a small inline form with three select fields matching `references/index.yml` schema:
+  - `composition` (poster · broadsheet · gallery · scroll · split · stack · specimen · index)
+  - `mood` (warm · cold · energetic · calm · dramatic · minimal · playful · serious)
+  - `density` (sparse · moderate · dense)
+- Optional `description` text input
+- Submit → calls a Vite dev-server endpoint (mirror the pattern from `vite.config.ts:81` lines added in commit `d91b3e1`)
+
+**Server side (Vite middleware in `vite.config.ts`):**
+- Endpoint: `POST /api/mark-as-reference` (dev-only middleware)
+- Body: `{ date, composition, mood, density, description }`
+- Action:
+  1. Copy `public/archive/$date.png` to `references/$date.png`
+  2. Append a YAML entry to `references/index.yml` matching the existing schema (file, url, description, tags)
+  3. Return success
+
+User then commits the changes manually. Pipeline picks them up on the next run via `scripts/collect-references.js`.
+
+**Hard gate:** middleware checks `process.env.NODE_ENV !== 'production'` AND request comes from localhost (already an existing pattern in dev-panel infra). Production builds never include the button OR the endpoint.
+
+### Part D — Light identity treatment
+
+The archive is "fixed identity" — meaning consistent across days, not stylized to today's daily redesign. But "fixed" doesn't mean "default browser styles." Define a small set of archive-specific tokens in a single CSS file (`app/styles/archive.css` or inline in the routes):
+
+- Type: one display face for the page header (e.g., a serif like `Fraunces` or `DM Serif Display`), system stack for body
+- Color: neutral palette — off-white bg, warm grey text, single accent (pick one — e.g., a deep ink blue or burnt orange)
+- Spacing: existing `maxWidth: 720` for detail / `760` for index — keep
+- Use CSS variables so it's easy to tweak
+
+Don't over-design. Goal is "this is clearly an archive, not the live site, and it's polished" — not "this has its own complex design system."
+
+## Acceptance criteria
+
+- [ ] Index page rows show a thumbnail + text layout, with a fallback for missing screenshots
+- [ ] Detail page leads with the hero screenshot, followed by brief / tokens / signals / actions
+- [ ] Hero has a clear "view archived site" affordance (click or explicit link)
+- [ ] In `npm run dev`, the detail page shows a "Mark as reference" button; submitting writes to `references/index.yml` and copies the screenshot to `references/`
+- [ ] In production build (`npm run build`), the button is absent and the endpoint returns 404
+- [ ] Loading skeletons (Spec 04) updated to match the new layouts (thumbnail-shaped block on index rows; hero-shaped block on detail)
+- [ ] Archive looks visibly distinct from the live daily-redesigning site — same site, different room
+- [ ] No layout shift on slow image load — thumbnails reserve their space
+
+## Risks
+
+- **Thumbnail performance.** Listing 30+ days × ~200KB PNGs = significant bandwidth on the index. Mitigations:
+  - Generate WebP variants in the pipeline's screenshot step (smaller files)
+  - Lazy-load with `loading="lazy"` on `<img>`
+  - Optionally, generate small thumb variants (`$date.thumb.png`) at build time
+- **Reference library committing requires the user.** Mark-as-reference writes to disk in dev — user must `git commit && push` for the pipeline to pick it up. Document this clearly in the form's success message.
+- **Out-of-scope creep.** "Visual redesign" is open-ended. Lock to the four parts above; further visual work is a separate spec.
+
+## Open questions for the implementer
+
+- WebP/thumb generation can happen as a fast follow if the bandwidth concern doesn't materialize at current archive size (~30 days). Worth measuring before optimizing.
+- Whether to break the hero out of the 720 maxWidth on detail — try both at execution time and pick what looks better.

--- a/docs/specs/06-pipeline-variance.md
+++ b/docs/specs/06-pipeline-variance.md
@@ -1,0 +1,108 @@
+# Spec 06 — Pipeline variance (instrumentation + soft guidance)
+
+**Status:** ready to execute
+**Depends on:** none, but Spec 03 (chaos chassis) interacts — chassis variance needs the catalog from Spec 03 to be meaningful
+
+## Goal
+
+Surface variance metrics to both the pipeline (informs next-day decisions via prompt injection) and the user (informs whether to dial weights or push specific vibes). **Never hard-block.** Best design today wins over diversity today.
+
+## Guiding principle
+
+> Fit > novelty. If today's signals genuinely call for archetype X and X was used 3 days ago, picking X again is the right answer. Variance metrics inform the agent's weighing — they don't constrain its choice.
+
+## What already exists (extend, do not overwrite)
+
+The color-mandate system is the template — same pattern applies to other dimensions.
+
+| Existing | What it does |
+|----------|-------------|
+| `scripts/utils/color-mandate.js` | Reads last N days of `archive/`, extracts primary hue from `color-scheme.json` or regex on `preset.ts`, computes target hue range + forbidden zones |
+| `scripts/design-agents.js:690-732` | Calls `computeColorMandate`, formats with `formatMandateForPrompt`, injects as `colorMandateSection` into Director and Token Designer prompts |
+| `interpret-signals.js:211-228` | "Run diversity" + "Previous brief — DO NOT REPEAT" injections (single-day lookback) |
+
+Result: palettes already self-diversify. Archetype, chassis, and scale ratios do not.
+
+## Decisions
+
+| Question | Decision |
+|----------|----------|
+| Hard rules vs soft guidance | **Soft only.** No filtering, no rejection, no required-different. Prompt-level informational context. |
+| Symptom-driven or proactive | **Proactive instrumentation.** Build the dashboard now, decide on enforcement later if patterns are bad. |
+| Storage | Extend existing pattern — read `archive/$date/build-*/` artifacts directly. No new persistence. |
+| Lookback window | **14 days** for archetype and chassis (matches color-mandate's typical window — verify exact value during execution). |
+| Dev dashboard | **Yes** — `/dev/variance` mirroring the existing `/dev/responsive` pattern (commit `a2f7e19`). |
+
+## Implementation outline
+
+### Part A — Archetype variance utility
+
+New file: `scripts/utils/archetype-variance.js`
+
+Mirrors `color-mandate.js` shape:
+- `extractRecentArchetypes(archiveDir, lookbackDays)` — reads `_detail.json` (or `brief.md` archetype declaration) for each day, returns ordered list
+- `computeArchetypeContext(hues, lookbackDays)` — returns `{ recent: [...], frequency: {...}, dominantArchetype: string|null, daysSinceEachArchetype: {...} }`
+- `formatArchetypeContextForPrompt(context)` — terse markdown block, max ~6 lines
+
+Injection point: `interpret-signals.js`, before the existing "DO NOT REPEAT" section. New section header: `## Recent Archetype Context (informational)`.
+
+Wording: "Here's what's been used recently. Choose the archetype that BEST fits today's signals — variance is informational. If today's signals call for a recently-used archetype, use it. If two archetypes fit equally well, the less-recent one wins."
+
+### Part B — Chassis variance utility
+
+New file: `scripts/utils/chassis-variance.js`
+
+Same shape as Part A, but reads each archived day's chosen chassis identifier. Source location depends on what the orchestrator persists today — verify during execution. If chassis isn't currently captured per-build, add a small `chassis.json` artifact in the build dir as part of this spec.
+
+Injection point: Director prompt (where chassis selection happens) and Token Designer prompt (so palette can coordinate, per Spec 03 Part C).
+
+### Part C — Color-mandate parity check
+
+Verify `color-mandate.js` is using the same lookback-window value the new utilities will use. If they're inconsistent, align them.
+
+No changes to `color-mandate.js` itself unless inconsistency is found.
+
+### Part D — `/dev/variance` dashboard
+
+New route: `app/routes/dev.variance.tsx`. Pattern after `app/routes/dev.responsive.tsx`.
+
+Read-only views of variance over the last 14/30/60 days:
+
+1. **Archetype timeline** — horizontal strip, one cell per day, colored by archetype. Hover → date + archetype name.
+2. **Palette swatches** — strip of primary-hue swatches, one per day. Quick visual sense of palette diversity.
+3. **Chassis usage histogram** — bar chart of chassis selections in the window.
+4. **Risk weight history** — line chart of `WEIGHT_RISK` values per run, to correlate variance with the dial.
+5. **Spec-critic revision rate** — bar chart, days where the critic forced revisions. Spikes here suggest over-constraint.
+
+Server function: `getVarianceData()` — calls the variance utilities + reads risk weights from build traces. Reuses the data-loading patterns already in `dev.responsive.tsx`.
+
+### Part E — Prompt safety language
+
+Every variance injection includes this stock line at the end:
+
+> Variance is informational. Choose what FITS the brief best. If today's brief and signals genuinely call for something recent, use it.
+
+This is the "fit > novelty" guarantee, repeated in every variance section so it can't get lost in prompt revisions.
+
+## Acceptance criteria
+
+- [ ] `scripts/utils/archetype-variance.js` exists with the same export shape as `color-mandate.js`
+- [ ] `scripts/utils/chassis-variance.js` exists with the same export shape
+- [ ] Both inject into the appropriate prompts via the same orchestrator pattern as `colorMandateSection`
+- [ ] `/dev/variance` dashboard renders with 5 visualizations populated from real archive data
+- [ ] After 14 days running, the dashboard shows non-trivial diversity in archetype and chassis without spec-critic revision rate spiking
+- [ ] No hard rejection paths — model is never blocked from picking a recently-used archetype/chassis if it justifies the choice
+- [ ] If an archetype is genuinely the right call N days in a row, the model picks it N days in a row (test by manually overriding signals to force a "specimen day" twice — second day should still pick specimen if it fits)
+
+## Risks
+
+- **Over-correction toward novelty.** If the prompt language tilts too far, the model picks rare archetypes for novelty's sake even when they don't fit. Mitigation: Part E stock language; eye-test acceptance criterion above.
+- **Prompt bloat.** Each variance section adds ~6 lines × multiple dimensions. Mitigation: hard cap each formatter at 6 lines; keep injection terse.
+- **Chassis tracking gap.** If chassis isn't currently persisted per-build, Part B requires a small instrumentation change. Verify at execution time.
+- **Dashboard becomes the goal.** It's easy to over-tune from a dashboard. Treat the dashboard as informational — only act on patterns visible across 30+ days.
+
+## Out of scope (future)
+
+- Hard rules (e.g., "no archetype repeat within N days"). If, after 30 days of soft variance, designs still feel repetitive, revisit.
+- Auto-tuning weights based on variance metrics (closed-loop control). Possible later — not now.
+- A "variance score" that summarizes diversity in a single number. Possible later — pick the right metric only after seeing real data on the dashboard.

--- a/docs/specs/07-claude-cli-version-bump.md
+++ b/docs/specs/07-claude-cli-version-bump.md
@@ -1,0 +1,74 @@
+# Spec 07 — Bump Claude CLI past 2.1.92
+
+**Status:** ready to execute
+**Depends on:** none
+**Cost:** $0 — entire test loop runs locally on Max plan auth
+
+## Goal
+
+Move the pinned Claude CLI version past `2.1.92` (latest as of writing: `2.1.120`), unlocking CLI improvements while verifying the original "0KB output for large prompts" regression (PR #40, March 2026) is no longer present.
+
+## Why this is testable locally
+
+The CLI binary is the same in both environments — the only difference is auth mode:
+
+- **CI** — `ANTHROPIC_API_KEY` env var present → CLI uses the API
+- **Local** — env var absent → CLI uses Max plan subscription
+
+The original failure was about **CLI prompt-handling behavior with large (~56KB) inputs** — upstream of auth. Local exercise of the CLI tests the same code path that broke.
+
+## Approach
+
+### Phase 1 — Local discovery (no cost)
+
+1. Install the candidate CLI version locally:
+   ```
+   npm install -g @anthropic-ai/claude-code@2.1.120
+   ```
+2. Run the daily redesign pipeline locally with the largest realistic prompt:
+   ```
+   node scripts/daily-redesign.js
+   ```
+   (Max plan auth picks up automatically because `ANTHROPIC_API_KEY` is absent from `.env` — confirmed by project convention.)
+3. Verify each agent stage produces non-empty output:
+   - interpret-signals → brief written
+   - design-director → visual spec captured
+   - token-designer → preset.ts + __root.tsx written, non-zero size
+   - unified-designer → all expected files written, each non-zero (this is the stage that historically failed with 0KB output)
+   - screenshot-critic → review captured
+4. Inspect output quality — eye-test against a recent production build.
+
+### Phase 2 — Binary search if Phase 1 fails
+
+If `2.1.120` produces 0KB output (or any other regression):
+
+- Try `2.1.93` (the version immediately after the pinned one). If it works, the regression came in 2.1.94 — test 2.1.94 to confirm, then walk forward to find the last good version
+- If 2.1.93 fails, the regression spans the entire 2.1.93+ range — file an issue with Anthropic and stay on 2.1.92
+
+### Phase 3 — CI confidence check (~$2)
+
+Once a local-passing version is identified:
+
+1. Update the pin in `.github/workflows/daily-redesign.yml:47`
+2. Trigger one `workflow_dispatch` with `dry_run: true`
+3. Verify the run completes end-to-end with non-empty designer output
+4. If pass: merge the pin bump
+5. If fail despite local pass: revert pin, document the divergence, file an issue
+
+## Acceptance criteria
+
+- [ ] Local run with new CLI version produces non-empty output at every agent stage
+- [ ] Output quality is at parity with recent production builds (eye test, no obvious regressions)
+- [ ] CI dry-run completes successfully
+- [ ] Pin updated, change committed, no rollback needed within 7 days of bump
+
+## Risks
+
+- **Local CLI behavior may diverge from CI in subtle ways.** Mitigation: Phase 3 dry-run before declaring done.
+- **Max plan rate limits during testing.** If multiple full runs are needed, queue them. Not a $-cost issue, just a wall-clock pacing one.
+- **Newer CLI may have different default behavior.** E.g., model selection defaults, tool defaults. The pipeline pins models per-agent (`claude-cli.js:58`) so this should be insulated. Verify per-agent options still parse on the new CLI.
+
+## Out of scope
+
+- Updating to a CLI major version (`@latest` could be 3.x someday). This spec covers minor/patch bumps within 2.x.
+- Replacing the CLI with the Anthropic SDK across all agents. The interpret-signals stage already uses the SDK in API mode; design-agents stages use the CLI in both modes by design.

--- a/docs/specs/08-close-pipeline-failure-issues.md
+++ b/docs/specs/08-close-pipeline-failure-issues.md
@@ -1,0 +1,68 @@
+# Spec 08 — Close resolved pipeline-failure GitHub issues
+
+**Status:** ready to execute
+**Depends on:** none
+**Estimated effort:** 30 minutes (mostly investigating the three unknowns)
+
+## Goal
+
+Triage and close the eight open issues with the `pipeline-failure` label. Five have known causes already resolved. Three pre-date the recent failures and need a quick look to determine whether they were transient or symptomatic of a real bug.
+
+## Inventory
+
+| Issue | Date | Cause | Resolved by | Action |
+|-------|------|-------|-------------|--------|
+| [#54](https://github.com/marchdoe/doug-march.com/issues/54) | 2026-04-25 | Error-sniff false positive on valid brief | PR #55 (merged 2026-04-26) | Close — comment refs PR #55 |
+| [#53](https://github.com/marchdoe/doug-march.com/issues/53) | 2026-04-24 | Anthropic API credit balance depleted | Credits topped up 2026-04-26 | Close — comment refs top-up |
+| [#52](https://github.com/marchdoe/doug-march.com/issues/52) | 2026-04-23 | Anthropic API credit balance depleted | Credits topped up 2026-04-26 | Close — comment refs top-up |
+| [#51](https://github.com/marchdoe/doug-march.com/issues/51) | 2026-04-22 | Anthropic API credit balance depleted | Credits topped up 2026-04-26 | Close — comment refs top-up |
+| [#50](https://github.com/marchdoe/doug-march.com/issues/50) | 2026-04-21 | Anthropic API credit balance depleted | Credits topped up 2026-04-26 | Close — comment refs top-up |
+| [#48](https://github.com/marchdoe/doug-march.com/issues/48) | 2026-04-16 | **Unknown** | — | Investigate (see below) |
+| [#45](https://github.com/marchdoe/doug-march.com/issues/45) | 2026-04-14 | **Unknown** | — | Investigate (see below) |
+| [#43](https://github.com/marchdoe/doug-march.com/issues/43) | 2026-04-12 | **Unknown** | — | Investigate (see below) |
+
+## Implementation outline
+
+### Step 1 — Close the five known
+
+For each of #54, #53, #52, #51, #50:
+
+```
+gh issue close <num> --comment "Resolved — see <reference>. <one-line context>."
+```
+
+Reference for #54: `PR #55`. Reference for the rest: `top-up on 2026-04-26 + 4 successful runs since`.
+
+### Step 2 — Investigate the three unknowns
+
+For each of #48 (2026-04-16), #45 (2026-04-14), #43 (2026-04-12):
+
+1. Look at the issue body — it contains a link to the original Actions run
+2. Pull the failed log:
+   ```
+   gh run view <run_id> --log-failed | grep -E "(Error|error|FAIL|##\[error)"
+   ```
+3. Categorize the failure into one of:
+   - **Transient infra** (runner / network / Vercel hiccup) → close as `Resolved — transient`
+   - **Same root cause as #50–53** (credit issue chain that started earlier) → close as `Resolved — credits`
+   - **Real bug not yet fixed** → leave open, retitle to describe the actual bug, remove `pipeline-failure` label, replace with `bug`. File a new issue if the existing title obscures the real problem.
+   - **Real bug already fixed** → close with comment naming the fixing PR
+
+### Step 3 — Group orphan bugs (if any)
+
+If Step 2 turns up a real, unfixed bug across multiple of the three unknowns, open one consolidated issue describing the underlying problem and link the original three to it before closing them.
+
+## Acceptance criteria
+
+- [ ] All eight issues are either closed (with descriptive comment + reference) or relabeled to a non-`pipeline-failure` category with an accurate title
+- [ ] No remaining `pipeline-failure` issues are stale (older than the most recent successful runs without explanation)
+- [ ] If a real bug surfaces in Step 2, it has a tracking issue and a clear next step (or is fixed and closed)
+
+## Risks
+
+- **Hiding a real bug.** Mitigation: don't bulk-close the unknowns; categorize each via the failed-log step.
+- **Lost context if we close too aggressively.** Mitigation: every close comment names the resolution explicitly so future searches surface the cause.
+
+## Out of scope
+
+- Building automated triage for future pipeline-failure issues. The notification workflow already creates these issues on every failure (`.github/workflows/daily-redesign.yml:93-114`); auto-closing them on the next successful run is a future improvement, not part of this spec.

--- a/docs/specs/09-dependabot-follow-redirects.md
+++ b/docs/specs/09-dependabot-follow-redirects.md
@@ -1,0 +1,90 @@
+# Spec 09 — Resolve dependabot alert #325 (follow-redirects)
+
+**Status:** ready to execute
+**Depends on:** none
+**Estimated effort:** 15 minutes
+
+## Goal
+
+Close [dependabot alert #325](https://github.com/marchdoe/doug-march.com/security/dependabot/325) by upgrading `follow-redirects` to a patched version.
+
+## Vulnerability summary
+
+| Field | Value |
+|-------|-------|
+| Package | `follow-redirects` |
+| Severity | Medium |
+| Issue | Leaks custom Authorization headers to cross-domain redirect targets |
+| Fixed in | `1.16.0` |
+| Status | Transitive dependency — not a direct dependency in `package.json` |
+
+## Implementation outline
+
+### Step 1 — Identify parent
+
+```
+pnpm why follow-redirects
+```
+
+This shows which top-level dep is pulling in the vulnerable version. Common candidates: `axios`, dev tooling, anything HTTP client-flavored.
+
+### Step 2 — Apply the override
+
+In `package.json`, add or extend `pnpm.overrides`:
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "follow-redirects": "^1.16.0"
+    }
+  }
+}
+```
+
+Use `^1.16.0` (not `>=1.16.0`) so future major-version changes don't sneak in.
+
+If a `pnpm.overrides` block already exists for other packages, add to it — don't create a second.
+
+### Step 3 — Refresh lockfile and test
+
+```
+pnpm install
+pnpm test
+pnpm build
+```
+
+The build step is the meaningful integration test for an HTTP-flavored dep — make sure CI-like flow still works end-to-end.
+
+### Step 4 — Verify the fix
+
+```
+pnpm why follow-redirects
+```
+
+Confirm only `1.16.0` (or higher) appears. No nested duplicates of older versions.
+
+### Step 5 — PR
+
+- Branch: `fix/dependabot-325-follow-redirects`
+- Title: `fix(deps): override follow-redirects to ^1.16.0 (CVE-XXXX)` (use the actual CVE from the alert page if listed)
+- Body: link the dependabot alert; one-line summary of the vulnerability; confirmation that tests pass
+- Once merged, the alert auto-resolves on the next dependabot scan (or close it manually with a "fixed via override" comment)
+
+## Acceptance criteria
+
+- [ ] `pnpm why follow-redirects` shows only versions `>= 1.16.0`
+- [ ] `pnpm test` passes
+- [ ] `pnpm build` completes successfully
+- [ ] Dependabot alert #325 is closed (auto or manual)
+- [ ] No new alerts surfaced by the override
+
+## Risks
+
+- **Override breaks a transitive caller.** Older `follow-redirects` versions had a different behavior around redirect-loop detection. Mitigation: tests + build verify the surface we use; if a specific dev tool breaks, address that separately.
+- **The override doesn't propagate.** pnpm's override lives in `package.json`; if a dependency uses a different package manager pattern (e.g., bundles its deps), the override may not apply. Mitigation: Step 4 verification.
+
+## Out of scope
+
+- Auditing the rest of the dependency tree for similar vulnerabilities. This spec resolves #325 only.
+- Removing the parent dependency that pulled in `follow-redirects`. That's a bigger architectural decision worth its own consideration.


### PR DESCRIPTION
## Summary

- New \`TODO.md\` at the repo root, linked from the README — the live backlog of pending work, each item pointing at a spec doc under \`docs/specs/\`.
- 9 self-contained spec docs covering every open item, from production pipeline improvements through housekeeping. Each spec captures verified state, decisions with rationale, implementation outline, acceptance criteria, and risks.
- **No code changes.** This branch sets up future work, not start it.

## What's specced

| # | Item | Spec |
|---|------|------|
| 1 | Awwwards screenshots → API image content blocks | [`01`](docs/specs/01-awwwards-screenshots-image-blocks.md) |
| 2 | Designer / React Engineer split | [`02`](docs/specs/02-designer-engineer-split.md) |
| 3 | Token Designer chaos mode | [`03`](docs/specs/03-token-chaos-mode.md) |
| 4 | Archive loading states | [`04`](docs/specs/04-archive-loading-states.md) |
| 5 | Archive visual redesign + mark-as-reference | [`05`](docs/specs/05-archive-visual-redesign.md) |
| 6 | Pipeline variance instrumentation | [`06`](docs/specs/06-pipeline-variance.md) |
| 7 | Bump Claude CLI past 2.1.92 | [`07`](docs/specs/07-claude-cli-version-bump.md) |
| 8 | Close pipeline-failure issues | [`08`](docs/specs/08-close-pipeline-failure-issues.md) |
| 9 | Dependabot alert #325 | [`09`](docs/specs/09-dependabot-follow-redirects.md) |

## Design principles followed

- **Extend, don't overwrite.** Specs lean on existing systems wherever possible:
  - Spec 03 (chaos mode) extends the existing \`color-mandate.js\` + chassis catalog rather than introducing parallel infrastructure
  - Spec 05 (mark-as-reference) reuses the dev-panel gating pattern and the still-active \`references/index.yml\` infrastructure
  - Spec 06 (variance) mirrors \`color-mandate.js\`'s shape for archetype + chassis dimensions
- **Best design every day > diversity for its own sake.** Spec 06 explicitly chose soft prompt guidance over hard rules; \"fit > novelty\" is locked in as stock language.
- **Verified state, not assumed state.** Every spec started with a code audit. Stale memory items (e.g., \"Save as Reference removed\") were verified before respecified.

## Test plan

- [ ] Browse \`docs/specs/\` and confirm each spec is self-contained — a fresh session could pick one up cold and execute
- [ ] Confirm \`TODO.md\` link from README renders correctly on GitHub
- [ ] Spot-check that no implementation files were modified (only docs added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)